### PR TITLE
Enable custom minimum row height for components (#475)

### DIFF
--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/Spreadsheet.java
@@ -382,6 +382,11 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
     private Set<Integer> rowsWithComponents;
 
     /**
+     * Minimum row height for rows containing components (in points).
+     */
+    private int minimumRowHeightForComponents = 30;
+
+    /**
      * Creates a new Spreadsheet component using the newer Excel version format
      * {@link XSSFWorkbook}. Also creates one sheet using the default row
      * {@link SpreadsheetFactory#DEFAULT_ROWS} and column
@@ -3578,8 +3583,8 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
                 continue;
             }
             float currentHeight = getState(false).rowH[row];
-            if (currentHeight < MINIMUM_ROW_HEIGHT_FOR_COMPONENTS) {
-                getState().rowH[row] = MINIMUM_ROW_HEIGHT_FOR_COMPONENTS;
+            if (currentHeight < getMinimumRowHeightForComponents()) {
+                getState().rowH[row] = getMinimumRowHeightForComponents();
             }
         }
         // Reset row height for rows which no longer have components
@@ -5089,4 +5094,23 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
         sheetOverlays.add(image);
     }
 
+    /**
+     * Get the minimum row heigth in points for the rows that contain custom
+     * components
+     * @return the minimum row heigths in points
+     */
+    public int getMinimumRowHeightForComponents() {
+        return minimumRowHeightForComponents;
+    }
+
+    /***
+     * Set the minimum row heigth in points for the rows that contain custom
+     * components. If set to a small value, it might cause some components
+     * like checkboxes to be cut off
+     * @param minimumRowHeightForComponents the minimum row height in points
+     */
+    public void setMinimumRowHeightForComponents(
+            final int minimumRowHeightForComponents) {
+        this.minimumRowHeightForComponents = minimumRowHeightForComponents;
+    }
 }

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/junit/MinimumRowHeightCustomComponentsTest.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/junit/MinimumRowHeightCustomComponentsTest.java
@@ -1,0 +1,99 @@
+package com.vaadin.addon.spreadsheet.test.junit;
+
+import com.vaadin.addon.spreadsheet.Spreadsheet;
+import com.vaadin.addon.spreadsheet.SpreadsheetComponentFactory;
+import com.vaadin.addon.spreadsheet.shared.SpreadsheetState;
+import com.vaadin.ui.Component;
+import com.vaadin.ui.Label;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFCell;
+import org.apache.poi.xssf.usermodel.XSSFRow;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+
+public class MinimumRowHeightCustomComponentsTest {
+
+    private static final float CUSTOM_ROW_HEIGTH = 15f;
+    private PublicSpreadsheet spreadsheet;
+
+    private static class PublicSpreadsheet extends Spreadsheet {
+        PublicSpreadsheet(Workbook wb) {
+            super(wb);
+        }
+
+        @Override
+        public void onSheetScroll(int firstRow, int firstColumn, int lastRow,
+                                  int lastColumn) {
+            super.onSheetScroll(firstRow, firstColumn, lastRow, lastColumn);
+        }
+
+        @Override
+        public SpreadsheetState getState() {
+            return super.getState();
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        XSSFWorkbook workbook = new XSSFWorkbook();
+        final XSSFSheet first = workbook.createSheet("First");
+        final XSSFRow row = first.createRow(1);
+        row.setHeightInPoints(CUSTOM_ROW_HEIGTH);
+        final XSSFCell onlyCell = row.createCell(1);
+        final Component component = new Label("hello");
+
+        SpreadsheetComponentFactory factory = new SpreadsheetComponentFactory() {
+            @Override
+            public Component getCustomComponentForCell(
+                    final Cell cell, final int rowIndex, final int columnIndex,
+                    final Spreadsheet spreadsheet,
+                    final Sheet sheet) {
+                if (cell != null &&
+                        cell.getRowIndex() == onlyCell.getRowIndex() && cell.getColumnIndex() == onlyCell.getColumnIndex()) {
+                    return component;
+                }
+                return null;
+            }
+
+            @Override
+            public Component getCustomEditorForCell(
+                    final Cell cell, final int rowIndex, final int columnIndex,
+                    final Spreadsheet spreadsheet,
+                    final Sheet sheet) {
+                return null;
+            }
+
+            @Override
+            public void onCustomEditorDisplayed(
+                    final Cell cell, final int rowIndex, final int columnIndex,
+                    final Spreadsheet spreadsheet,
+                    final Sheet sheet, final Component customEditor) {
+            }
+        };
+        spreadsheet = new PublicSpreadsheet(workbook);
+        spreadsheet.setSpreadsheetComponentFactory(factory);
+        new TestableUI(spreadsheet);
+    }
+
+    @Test
+    public void defaultMinimumRowHeightIs30() throws Exception {
+        spreadsheet.onSheetScroll(1, 1, 20, 20);
+        spreadsheet.reloadVisibleCellContents();
+        assertThat(spreadsheet.getState().rowH[1], is(30f));
+    }
+
+    @Test
+    public void defaultMinimumRowHeightDifferentFromDefault() throws Exception {
+        spreadsheet.setMinimumRowHeightForComponents(10);
+        spreadsheet.onSheetScroll(1, 1, 20, 20);
+        spreadsheet.reloadVisibleCellContents();
+        assertThat(spreadsheet.getState().rowH[1], is(CUSTOM_ROW_HEIGTH));
+    }
+}


### PR DESCRIPTION
* change the MINIMUM_ROW_HEIGHT_FOR_COMPONENTS static field into a non final instance field and added getter and setter

* added a warning in the Spreadsheet.setMinimumRowHeightForComponents Javadoc

* added simple JUnit test that uses the TestableUI class

Fixes #245

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet/476)
<!-- Reviewable:end -->
