### PR TITLE
Fix #519, text overflow in the presence of a split pane on rows only

### DIFF
--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
@@ -128,18 +128,18 @@ public class Cell {
             int colIndex = col;
             int width = 0;
             int[] colW = sheetWidget.actionHandler.getColWidths();
-            boolean inFreezePane = col <= sheetWidget.verticalSplitPosition;
+            boolean inFreezePane = sheetWidget.hasFrozenColumns() && sheetWidget.isCellRenderedInFrozenPane(colIndex, row);
 
             while (colIndex < colW.length && width < overflowPx) {
                 if (inFreezePane
-                        && colIndex >= sheetWidget.verticalSplitPosition) {
+                        && sheetWidget.isCellRenderedInFrozenPane(colIndex, row) ) {
                     break;
                 }
                 Cell nextCell = sheetWidget.getCell(colIndex + 1, row);
                 if (nextCell != null && nextCell.hasValue()) {
                     break;
                 }
-                width += colW[colIndex];
+                width +=sheetWidget.actionHandler.getColWidth(colIndex);
                 colIndex++;
             }
             // columnWidth is added after calculating the overflowing width


### PR DESCRIPTION
This fixes the overflow logic when there are freeze panes, especially when there are only frozen rows, not columns.

This change uses methods already present in the sheet object to handle freeze panes and column widths, including default column widths if necessary.