### PR TITLE
fix for issue #550

### DIFF
--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/junit/CellValueChangeEventOnFormulaChangeTest.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/junit/CellValueChangeEventOnFormulaChangeTest.java
@@ -1,0 +1,57 @@
+package com.vaadin.addon.spreadsheet.test.junit;
+
+import com.vaadin.addon.spreadsheet.Spreadsheet;
+
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellReference;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Unit test for fix for issue #550.
+ *
+ * @author Ian Scriven
+ */
+public class CellValueChangeEventOnFormulaChangeTest {
+
+    private Spreadsheet spreadsheet;
+
+    @Before
+    public void setup() {
+        Workbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet();
+        Row row = sheet.createRow(0);
+        row.createCell(0).setCellValue(1);
+        row.createCell(1).setCellValue(0);
+        row.createCell(2).setCellFormula("A1+B1");
+
+        spreadsheet = new Spreadsheet();
+        spreadsheet.setWorkbook(workbook);
+    }
+
+    /**
+     * Verify that a CellValueChangeEvent is fired when a cell's formula changes, but the new formula still produces
+     * the same result as the previous formula.
+     */
+    @Test
+    public void formulaChangeResultingInSameValue() {
+        List<CellReference> changedCells = new LinkedList<>();
+
+        spreadsheet.addCellValueChangeListener(event -> changedCells.addAll(event.getChangedCells()));
+
+        spreadsheet.setSelection("C1");
+        spreadsheet.getCellValueManager().onCellValueChange(3, 1, "=A1+2*B1"); // B1 is 0, so the result doesn't change
+
+        assertEquals("There should be 1 changed cell", 1, changedCells.size());
+        assertEquals("The changed cell should be C1", new CellReference("C1"), changedCells.get(0));
+    }
+
+}

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/junit/CellValueChangeEventOnFormulaChangeTest.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/junit/CellValueChangeEventOnFormulaChangeTest.java
@@ -1,6 +1,9 @@
 package com.vaadin.addon.spreadsheet.test.junit;
 
-import com.vaadin.addon.spreadsheet.Spreadsheet;
+import static org.junit.Assert.assertEquals;
+
+import java.util.LinkedList;
+import java.util.List;
 
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
@@ -10,15 +13,10 @@ import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.LinkedList;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
+import com.vaadin.addon.spreadsheet.Spreadsheet;
 
 /**
  * Unit test for fix for issue #550.
- *
- * @author Ian Scriven
  */
 public class CellValueChangeEventOnFormulaChangeTest {
 
@@ -38,20 +36,24 @@ public class CellValueChangeEventOnFormulaChangeTest {
     }
 
     /**
-     * Verify that a CellValueChangeEvent is fired when a cell's formula changes, but the new formula still produces
-     * the same result as the previous formula.
+     * Verify that a CellValueChangeEvent is fired when a cell's formula
+     * changes, but the new formula still produces the same result as the
+     * previous formula.
      */
     @Test
     public void formulaChangeResultingInSameValue() {
         List<CellReference> changedCells = new LinkedList<>();
 
-        spreadsheet.addCellValueChangeListener(event -> changedCells.addAll(event.getChangedCells()));
+        spreadsheet.addCellValueChangeListener(
+                event -> changedCells.addAll(event.getChangedCells()));
 
         spreadsheet.setSelection("C1");
-        spreadsheet.getCellValueManager().onCellValueChange(3, 1, "=A1+2*B1"); // B1 is 0, so the result doesn't change
+        // B1 is 0, so the result doesn't change
+        spreadsheet.getCellValueManager().onCellValueChange(3, 1, "=A1+2*B1");
 
         assertEquals("There should be 1 changed cell", 1, changedCells.size());
-        assertEquals("The changed cell should be C1", new CellReference("C1"), changedCells.get(0));
+        assertEquals("The changed cell should be C1", new CellReference("C1"),
+                changedCells.get(0));
     }
 
 }


### PR DESCRIPTION
- fire CellValueChangeEvent when cell formula is changed but the formula result is the same

Previously, a CellValueChangeEvent would only be fired if the updated formula resulted in a new/different value to the previous result.

For example, if you define the following spreadsheet:
A1: 0
A2: 1
A3: =A1+A2

and then change the formula in A3 to '=2*A1+A2' no CellValueChangeEvent is fired, as the formula still evaluates to 1. If you change the formula to '=A1+A2/2' then a CellValueChangeEvent is fired, as the formula now evaluates to a different value.

With this fix a CellValueChangeEvent is fired in both cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet/551)
<!-- Reviewable:end -->
