### PR TITLE
Use enums instead of deprecated int values

### DIFF
--- a/vaadin-spreadsheet-charts/src/main/java/com/vaadin/addon/spreadsheet/charts/converter/Utils.java
+++ b/vaadin-spreadsheet-charts/src/main/java/com/vaadin/addon/spreadsheet/charts/converter/Utils.java
@@ -25,6 +25,7 @@ import java.util.logging.Logger;
 
 import org.apache.poi.ss.formula.FormulaParseException;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.AreaReference;
 import org.apache.poi.ss.util.CellReference;
@@ -154,10 +155,10 @@ public class Utils {
             Sheet sheet = spreadsheet.getWorkbook()
                     .getSheet(ref.getSheetName());
             Cell cell = spreadsheet.getCell(ref, sheet);
-            spreadsheet.getFormulaEvaluator().evaluateFormulaCell(cell);
+            spreadsheet.getFormulaEvaluator().evaluateFormulaCellEnum(cell);
 
-            if (cell.getCellType() == Cell.CELL_TYPE_NUMERIC
-                    || cell.getCellType() == Cell.CELL_TYPE_FORMULA) {
+            if (cell.getCellTypeEnum() == CellType.NUMERIC
+                    || cell.getCellTypeEnum() == CellType.FORMULA) {
                 return cell.getNumericCellValue();
             }
         } catch (NullPointerException e) {

--- a/vaadin-spreadsheet/pom.xml
+++ b/vaadin-spreadsheet/pom.xml
@@ -24,7 +24,7 @@
         <testbench.version>5.1.0.alpha1</testbench.version>
         <testbench.api.version>${vaadin.version}</testbench.api.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
-        <poi.version>3.15</poi.version>
+        <poi.version>3.17-beta1</poi.version>
         <jetty.plugin.version>9.2.3.v20140905</jetty.plugin.version>
         <tb.hub>testbench-hub.intra.itmill.com</tb.hub>
     </properties>

--- a/vaadin-spreadsheet/pom.xml
+++ b/vaadin-spreadsheet/pom.xml
@@ -24,7 +24,7 @@
         <testbench.version>5.1.0.alpha1</testbench.version>
         <testbench.api.version>${vaadin.version}</testbench.api.version>
         <vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
-        <poi.version>3.17-beta1</poi.version>
+        <poi.version>3.15</poi.version>
         <jetty.plugin.version>9.2.3.v20140905</jetty.plugin.version>
         <tb.hub>testbench-hub.intra.itmill.com</tb.hub>
     </properties>

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellSelectionManager.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellSelectionManager.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellRangeAddress;
@@ -301,7 +302,7 @@ public class CellSelectionManager implements Serializable {
                 final Cell cell = row.getCell(colIndex - 1);
                 if (cell != null) {
                     String value = "";
-                    boolean formula = cell.getCellType() == Cell.CELL_TYPE_FORMULA;
+                    boolean formula = cell.getCellTypeEnum() == CellType.FORMULA;
                     if (!spreadsheet.isCellHidden(cell)) {
                         if (formula) {
                             value = cell.getCellFormula();
@@ -368,7 +369,7 @@ public class CellSelectionManager implements Serializable {
             final Cell cell = row.getCell(columnIndex - 1);
             if (cell != null) {
                 String value = "";
-                boolean formula = cell.getCellType() == Cell.CELL_TYPE_FORMULA;
+                boolean formula = cell.getCellTypeEnum() == CellType.FORMULA;
                 if (!spreadsheet.isCellHidden(cell)) {
                     if (formula) {
                         value = cell.getCellFormula();
@@ -407,7 +408,7 @@ public class CellSelectionManager implements Serializable {
             final Cell cell = row.getCell(col1);
             if (cell != null) {
                 String value = "";
-                boolean formula = cell.getCellType() == Cell.CELL_TYPE_FORMULA;
+                boolean formula = cell.getCellTypeEnum() == CellType.FORMULA;
                 if (!spreadsheet.isCellHidden(cell)) {
                     if (formula) {
                         value = cell.getCellFormula();
@@ -451,7 +452,7 @@ public class CellSelectionManager implements Serializable {
             final Cell cell = row.getCell(startingPoint.getCol());
             if (cell != null) {
                 String value = "";
-                boolean formula = cell.getCellType() == Cell.CELL_TYPE_FORMULA;
+                boolean formula = cell.getCellTypeEnum() == CellType.FORMULA;
                 if (!spreadsheet.isCellHidden(cell)) {
                     if (formula) {
                         value = cell.getCellFormula();

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellSelectionShifter.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellSelectionShifter.java
@@ -17,9 +17,6 @@ package com.vaadin.addon.spreadsheet;
  * #L%
  */
 
-import static org.apache.poi.ss.usermodel.Cell.CELL_TYPE_NUMERIC;
-import static org.apache.poi.ss.usermodel.Cell.CELL_TYPE_STRING;
-
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
@@ -29,6 +26,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -179,31 +177,31 @@ public class CellSelectionShifter implements Serializable {
             boolean removeShifted, Double sequenceIncrement) {
         // clear the new cell first because it might have errors which prevent
         // it from being set to a new type
-        if (newCell.getCellType() != Cell.CELL_TYPE_BLANK
-                || shiftedCell.getCellType() == Cell.CELL_TYPE_BLANK) {
-            newCell.setCellType(Cell.CELL_TYPE_BLANK);
+        if (newCell.getCellTypeEnum() != CellType.BLANK
+                || shiftedCell.getCellTypeEnum() == CellType.BLANK) {
+            newCell.setCellType(CellType.BLANK);
         }
-        newCell.setCellType(shiftedCell.getCellType());
+        newCell.setCellType(shiftedCell.getCellTypeEnum());
         newCell.setCellStyle(shiftedCell.getCellStyle());
         spreadsheet.getSpreadsheetStyleFactory()
                 .cellStyleUpdated(newCell, true);
-        switch (shiftedCell.getCellType()) {
-        case Cell.CELL_TYPE_FORMULA:
+        switch (shiftedCell.getCellTypeEnum()) {
+        case FORMULA:
             shiftFormula(shiftedCell, newCell);
             break;
-        case Cell.CELL_TYPE_BOOLEAN:
+        case BOOLEAN:
             newCell.setCellValue(shiftedCell.getBooleanCellValue());
             break;
-        case Cell.CELL_TYPE_ERROR:
+        case ERROR:
             newCell.setCellValue(shiftedCell.getErrorCellValue());
             break;
-        case Cell.CELL_TYPE_NUMERIC:
+        case NUMERIC:
             shiftNumeric(shiftedCell, newCell, sequenceIncrement);
             break;
-        case Cell.CELL_TYPE_STRING:
+        case STRING:
             shiftString(shiftedCell, newCell, sequenceIncrement);
             break;
-        case Cell.CELL_TYPE_BLANK:
+        case BLANK:
             // cell is cleared when type is set
         default:
             break;
@@ -635,9 +633,9 @@ public class CellSelectionShifter implements Serializable {
         if (row != null) {
             Cell firstCell = row.getCell(c1 - 1);
             if (firstCell != null) {
-                if (firstCell.getCellType() == CELL_TYPE_STRING) {
+                if (firstCell.getCellTypeEnum() == CellType.STRING) {
                     return getSequenceIncrement(getRowStringValues(row, c1, c2));
-                } else if (firstCell.getCellType() == CELL_TYPE_NUMERIC) {
+                } else if (firstCell.getCellTypeEnum() == CellType.NUMERIC) {
                     return getSequenceIncrement(getRowNumericValues(row, c1, c2));
                 }
             }
@@ -670,7 +668,7 @@ public class CellSelectionShifter implements Serializable {
             row = activeSheet.getRow(i - 1);
             if (row != null) {
                 cell = row.getCell(columnIndex - 1);
-                if (cell != null && cell.getCellType() == CELL_TYPE_STRING) {
+                if (cell != null && cell.getCellTypeEnum() == CellType.STRING) {
                     result[i - r1] = cell.getStringCellValue();
                 } else {
                     break;
@@ -707,7 +705,7 @@ public class CellSelectionShifter implements Serializable {
             row = activeSheet.getRow(i - 1);
             if (row != null) {
                 cell = row.getCell(columnIndex - 1);
-                if (cell != null && cell.getCellType() == CELL_TYPE_NUMERIC) {
+                if (cell != null && cell.getCellTypeEnum() == CellType.NUMERIC) {
                     result[i - r1] = cell.getNumericCellValue();
                 } else {
                     break;
@@ -737,7 +735,7 @@ public class CellSelectionShifter implements Serializable {
         Cell cell;
         for (int i = c1; i <= c2; i++) {
             cell = row.getCell(i - 1);
-            if (cell != null && cell.getCellType() == CELL_TYPE_STRING) {
+            if (cell != null && cell.getCellTypeEnum() == CellType.STRING) {
                 result[i - c1] = cell.getStringCellValue();
             } else {
                 break;
@@ -765,7 +763,7 @@ public class CellSelectionShifter implements Serializable {
         for (int i = c1; i <= c2; i++) {
             shiftedCell = row.getCell(i - 1);
             if (shiftedCell != null
-                    && shiftedCell.getCellType() == CELL_TYPE_NUMERIC) {
+                    && shiftedCell.getCellTypeEnum() == CellType.NUMERIC) {
                 result[i - c1] = shiftedCell.getNumericCellValue();
             } else {
                 break;
@@ -875,10 +873,10 @@ public class CellSelectionShifter implements Serializable {
         if (row != null) {
             Cell firstCell = row.getCell(cIndex - 1);
             if (firstCell != null) {
-                if (firstCell.getCellType() == CELL_TYPE_STRING) {
+                if (firstCell.getCellTypeEnum() == CellType.STRING) {
                     return getSequenceIncrement(getColumnStringValues(
                             activeSheet, cIndex, r1, r2));
-                } else if (firstCell.getCellType() == CELL_TYPE_NUMERIC) {
+                } else if (firstCell.getCellTypeEnum() == CellType.NUMERIC) {
                     return getSequenceIncrement(getColumnNumericValues(
                             activeSheet, cIndex, r1, r2));
                 }

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellValueManager.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellValueManager.java
@@ -49,9 +49,11 @@ import org.apache.poi.ss.formula.FormulaParseException;
 import org.apache.poi.ss.formula.eval.ErrorEval;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -186,19 +188,22 @@ public class CellValueManager implements Serializable {
 
     private String getCachedFormulaCellValue(Cell formulaCell) {
         String result = null;
-        switch (formulaCell.getCachedFormulaResultType()) {
-        case Cell.CELL_TYPE_STRING:
+        switch (formulaCell.getCachedFormulaResultTypeEnum()) {
+        case BLANK:
+        case FORMULA:
+        case _NONE:
+        case STRING:
             result = formulaCell.getStringCellValue();
             break;
-        case Cell.CELL_TYPE_BOOLEAN:
+        case BOOLEAN:
             result = String.valueOf(formulaCell
                     .getBooleanCellValue());
             break;
-        case Cell.CELL_TYPE_ERROR:
+        case ERROR:
             result = ErrorEval.getText(formulaCell
                     .getErrorCellValue());
             break;
-        case Cell.CELL_TYPE_NUMERIC:
+        case NUMERIC:
             CellStyle style = formulaCell.getCellStyle();
             result = formatter.formatRawCellContents(
                     formulaCell.getNumericCellValue(),
@@ -218,7 +223,7 @@ public class CellValueManager implements Serializable {
         cellData.locked = spreadsheet.isCellLocked(cell);
         try {
             if (!spreadsheet.isCellHidden(cell)) {
-                if (cell.getCellType() == Cell.CELL_TYPE_FORMULA) {
+                if (cell.getCellTypeEnum() == CellType.FORMULA) {
                     cellData.formulaValue = formulaFormatter
                             .reFormatFormulaValue(cell.getCellFormula(),
                                     spreadsheet.getLocale());
@@ -233,7 +238,7 @@ public class CellValueManager implements Serializable {
                         // Apache POI throws RuntimeExceptions for an invalid
                         // formula from POI model
                         String formulaValue = cell.getCellFormula();
-                        cell.setCellType(Cell.CELL_TYPE_STRING);
+                        cell.setCellType(CellType.STRING);
                         cell.setCellValue(formulaValue);
                         spreadsheet.markInvalidFormula(
                                 cell.getColumnIndex() + 1,
@@ -251,8 +256,8 @@ public class CellValueManager implements Serializable {
                     getFormulaEvaluator());
 
             if (!spreadsheet.isCellHidden(cell)) {
-                if (cell.getCellType() == Cell.CELL_TYPE_FORMULA
-                        || cell.getCellType() == Cell.CELL_TYPE_NUMERIC) {
+                if (cell.getCellTypeEnum() == CellType.FORMULA
+                        || cell.getCellTypeEnum() == CellType.NUMERIC) {
                     formattedCellValue = formattedCellValue.replaceAll(
                             "^-(?=0(.0*)?$)", "");
                 }
@@ -277,9 +282,9 @@ public class CellValueManager implements Serializable {
                 cellData.needsMeasure = false;
                 if (!cellStyle.getWrapText()
                         && (!SpreadsheetUtil.cellContainsDate(cell)
-                                && cell.getCellType() == Cell.CELL_TYPE_NUMERIC
-                                || cell.getCellType() == Cell.CELL_TYPE_STRING || (cell
-                                .getCellType() == Cell.CELL_TYPE_FORMULA && !cell
+                                && cell.getCellTypeEnum() == CellType.NUMERIC
+                                || cell.getCellTypeEnum() == CellType.STRING || (cell
+                                .getCellTypeEnum() == CellType.FORMULA && !cell
                                 .getCellFormula().startsWith("HYPERLINK")))) {
                     if (!doesValueFit(cell, formattedCellValue)) {
                         if (valueContainsOnlyNumbers(formattedCellValue)
@@ -294,23 +299,23 @@ public class CellValueManager implements Serializable {
                                                             .getIndex()),
                                             spreadsheet.getState(false).colW[cell
                                                     .getColumnIndex()] - 10);
-                        } else if (cell.getCellType() != Cell.CELL_TYPE_STRING
-                                && (cell.getCellType() == Cell.CELL_TYPE_FORMULA
-                                        && cell.getCachedFormulaResultType() != Cell.CELL_TYPE_STRING)) {
+                        } else if (cell.getCellTypeEnum() != CellType.STRING
+                                && (cell.getCellTypeEnum() == CellType.FORMULA
+                                        && cell.getCachedFormulaResultTypeEnum() != CellType.STRING)) {
                             cellData.needsMeasure = true;
                         }
                     }
                 }
 
-                if (cellStyle.getAlignment() == CellStyle.ALIGN_RIGHT) {
+                if (cellStyle.getAlignmentEnum() == HorizontalAlignment.RIGHT) {
                     cellData.cellStyle = cellData.cellStyle + " r";
-                } else if (cellStyle.getAlignment() == CellStyle.ALIGN_GENERAL) {
+                } else if (cellStyle.getAlignmentEnum() == HorizontalAlignment.GENERAL) {
                     if (SpreadsheetUtil.cellContainsDate(cell)
-                            || cell.getCellType() == Cell.CELL_TYPE_NUMERIC
-                            || (cell.getCellType() == Cell.CELL_TYPE_FORMULA
+                            || cell.getCellTypeEnum() == CellType.NUMERIC
+                            || (cell.getCellTypeEnum() == CellType.FORMULA
                                     && !cell.getCellFormula().startsWith(
                                             "HYPERLINK") && !(cell
-                                    .getCachedFormulaResultType() == Cell.CELL_TYPE_STRING))) {
+                                    .getCachedFormulaResultTypeEnum() == CellType.STRING))) {
                         cellData.cellStyle = cellData.cellStyle + " r";
                     }
                 }
@@ -330,7 +335,7 @@ public class CellValueManager implements Serializable {
                 markedCells.add(SpreadsheetUtil.toKey(cell));
             }
 
-            if (cell.getCellType() == Cell.CELL_TYPE_NUMERIC
+            if (cell.getCellTypeEnum() == CellType.NUMERIC
                     && DateUtil.isCellDateFormatted(cell)) {
                 cellData.originalValue = cellData.value;
             } else {
@@ -354,8 +359,8 @@ public class CellValueManager implements Serializable {
     }
 
     private void handleIsDisplayZeroPreference(Cell cell, CellData cellData) {
-        boolean isCellNumeric = cell.getCellType() == Cell.CELL_TYPE_NUMERIC;
-        boolean isCellFormula = cell.getCellType() == Cell.CELL_TYPE_FORMULA;
+        boolean isCellNumeric = cell.getCellTypeEnum() == CellType.NUMERIC;
+        boolean isCellFormula = cell.getCellTypeEnum() == CellType.FORMULA;
         boolean isApplicableCellType = isCellNumeric || isCellFormula;
 
         boolean displayZeroAsBlank = !cell.getSheet().isDisplayZeros();
@@ -372,7 +377,7 @@ public class CellValueManager implements Serializable {
      * for cells.
      */
     private boolean isGenerallCell(Cell cell) {
-        return cell.getCellType() == Cell.CELL_TYPE_NUMERIC
+        return cell.getCellTypeEnum() == CellType.NUMERIC
                 && cell.getCellStyle().getDataFormatString()
                         .contains("General");
     }
@@ -382,11 +387,11 @@ public class CellValueManager implements Serializable {
             return "";
         }
 
-        int cellType = cell.getCellType();
+        CellType cellType = cell.getCellTypeEnum();
         switch (cellType) {
-        case Cell.CELL_TYPE_FORMULA:
+        case FORMULA:
             return cell.getCellFormula();
-        case Cell.CELL_TYPE_NUMERIC:
+        case NUMERIC:
             if (DateUtil.isCellDateFormatted(cell)) {
                 Date dateCellValue = cell.getDateCellValue();
                 if (dateCellValue != null) {
@@ -396,20 +401,21 @@ public class CellValueManager implements Serializable {
             }
             return originalValueDecimalFormat
                     .format(cell.getNumericCellValue());
-        case Cell.CELL_TYPE_STRING:
+        case STRING:
             String stringCellValue = cell.getStringCellValue();
             if (SpreadsheetUtil.needsLeadingQuote(cell)) {
                 return "'" + stringCellValue;
             }
             return stringCellValue;
-        case Cell.CELL_TYPE_BOOLEAN:
+        case BOOLEAN:
             return String.valueOf(cell.getBooleanCellValue());
-        case Cell.CELL_TYPE_BLANK:
+        case BLANK:
             return "";
-        case Cell.CELL_TYPE_ERROR:
+        case ERROR:
             return String.valueOf(cell.getErrorCellValue());
+        default:
+        	return "";
         }
-        return "";
     }
 
     private boolean valueContainsOnlyNumbers(String value) {
@@ -575,7 +581,8 @@ public class CellValueManager implements Serializable {
         }
         Cell cell = r.getCell(col - 1);
         String formattedCellValue = null;
-        int oldCellType = -1;
+        CellType oldCellType = CellType._NONE;
+        
         // capture cell value to history
         CellValueCommand command = new CellValueCommand(spreadsheet);
         command.captureCellValues(new CellReference(row - 1, col - 1));
@@ -599,13 +606,13 @@ public class CellValueManager implements Serializable {
                     // modify existing cell, possibly switch type
                     formattedCellValue = getFormattedCellValue(cell);
                     final String key = SpreadsheetUtil.toKey(col, row);
-                    oldCellType = cell.getCellType();
+                    oldCellType = cell.getCellTypeEnum();
                     if (!sentCells.remove(key)) {
                         sentFormulaCells.remove(key);
                     }
 
                     // Old value was hyperlink => needs refresh
-                    if (cell.getCellType() == Cell.CELL_TYPE_FORMULA
+                    if (cell.getCellTypeEnum() == CellType.FORMULA
                             && cell.getCellFormula().startsWith("HYPERLINK")) {
                         updateHyperlinks = true;
                     }
@@ -619,10 +626,11 @@ public class CellValueManager implements Serializable {
                         String newFormula = formulaFormatter
                             .unFormatFormulaValue(value.substring(1),
                                                   spreadsheetLocale);
+
                         formulaChanged =
-                            ((cell.getCellType() == Cell.CELL_TYPE_FORMULA)
+                            ((cell.getCellTypeEnum() == CellType.FORMULA)
                                 && !newFormula.equals(cell.getCellFormula()));
-                        cell.setCellType(Cell.CELL_TYPE_FORMULA);
+                        cell.setCellType(CellType.FORMULA);
                         cell.setCellFormula(newFormula);
                         getFormulaEvaluator().notifySetFormula(cell);
                         if (value.startsWith("=HYPERLINK(")
@@ -643,7 +651,7 @@ public class CellValueManager implements Serializable {
                         }
                     } else {
                         // it's formula but invalid
-                        cell.setCellType(Cell.CELL_TYPE_STRING);
+                        cell.setCellType(CellType.STRING);
                         cell.setCellValue(value);
                         spreadsheet.markInvalidFormula(col, row);
                     }
@@ -654,9 +662,9 @@ public class CellValueManager implements Serializable {
                     Double numVal = SpreadsheetUtil.parseNumber(cell, value,
                             spreadsheetLocale);
                     if (value.isEmpty()) {
-                        cell.setCellType(Cell.CELL_TYPE_BLANK);
+                        cell.setCellType(CellType.BLANK);
                     } else if (percentage != null) {
-                        cell.setCellType(Cell.CELL_TYPE_NUMERIC);
+                        cell.setCellType(CellType.NUMERIC);
                         CellStyle cs = cell.getCellStyle();
                         // Do not use default cell style (index == 0) for
                         // percentage as it will affect all cells
@@ -676,16 +684,15 @@ public class CellValueManager implements Serializable {
                         }
                         cell.setCellValue(percentage);
                     } else if (numVal != null) {
-                        cell.setCellType(Cell.CELL_TYPE_NUMERIC);
+                        cell.setCellType(CellType.NUMERIC);
                         cell.setCellValue(numVal);
-                    } else if (oldCellType == Cell.CELL_TYPE_BOOLEAN) {
+                    } else if (oldCellType == CellType.BOOLEAN) {
                         cell.setCellValue(Boolean.parseBoolean(value));
                     } else {
                         if (value.startsWith("'")) {
                             value = value.substring(1, value.length());
                             setLeadingQuoteStyle(cell, true);
                         }
-                        cell.setCellType(Cell.CELL_TYPE_STRING);
                         cell.setCellValue(value);
                     }
                 }
@@ -703,7 +710,7 @@ public class CellValueManager implements Serializable {
                      * Instead, just store it as the value. Clearing the formula
                      * makes sure the value is displayed as-is.
                      */
-                    cell.setCellType(Cell.CELL_TYPE_STRING);
+                    cell.setCellType(CellType.STRING);
                     cell.setCellValue(value);
                     spreadsheet.markInvalidFormula(col, row);
                 }
@@ -721,7 +728,7 @@ public class CellValueManager implements Serializable {
                 if (formattedCellValue == null
                         || !formattedCellValue
                                 .equals(getFormattedCellValue(cell))
-                        || oldCellType != cell.getCellType()
+                        || oldCellType != cell.getCellTypeEnum()
                         || formulaChanged) {
                     fireCellValueChangeEvent(cell);
                 }
@@ -1099,8 +1106,8 @@ public class CellValueManager implements Serializable {
                         if (cell != null) {
                             final CellData cd = createCellDataForCell(cell);
                             if (cd != null) {
-                                int cellType = cell.getCellType();
-                                if (cellType == Cell.CELL_TYPE_FORMULA) {
+                                CellType cellType = cell.getCellTypeEnum();
+                                if (cellType == CellType.FORMULA) {
                                     sentFormulaCells.add(key);
                                 } else {
                                     sentCells.add(key);
@@ -1153,7 +1160,7 @@ public class CellValueManager implements Serializable {
                         rowIndex + 1);
                 CellData cd = createCellDataForCell(cell);
                 // update formula cells
-                if (cell.getCellType() == Cell.CELL_TYPE_FORMULA) {
+                if (cell.getCellTypeEnum() == CellType.FORMULA) {
                     if (cd != null) {
                         if (sentFormulaCells.contains(key)
                                 || markedCells.contains(key)) {
@@ -1256,7 +1263,7 @@ public class CellValueManager implements Serializable {
                     Cell cell = row.getCell(j);
                     if (cell != null) {
                         final String key = SpreadsheetUtil.toKey(j + 1, i + 1);
-                        if (cell.getCellType() == Cell.CELL_TYPE_FORMULA) {
+                        if (cell.getCellTypeEnum() == CellType.FORMULA) {
                             sentFormulaCells.remove(key);
                         } else {
                             sentCells.remove(key);
@@ -1320,7 +1327,7 @@ public class CellValueManager implements Serializable {
                 } else {
                     markedCells.add(key);
                 }
-                if (cell.getCellType() == Cell.CELL_TYPE_FORMULA) {
+                if (cell.getCellTypeEnum() == CellType.FORMULA) {
                     sentFormulaCells.remove(key);
                 } else {
                     sentCells.remove(key);

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/DefaultHyperlinkCellClickHandler.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/DefaultHyperlinkCellClickHandler.java
@@ -21,7 +21,9 @@ import static org.apache.poi.common.usermodel.Hyperlink.LINK_DOCUMENT;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.poi.common.usermodel.HyperlinkType;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Hyperlink;
 
 import com.vaadin.addon.spreadsheet.Spreadsheet.HyperlinkCellClickHandler;
@@ -57,7 +59,7 @@ public class DefaultHyperlinkCellClickHandler implements
     public void onHyperLinkCellClick(Cell cell, Hyperlink hyperlink,
             Spreadsheet spreadsheet) {
         if (hyperlink != null) {
-            if (hyperlink.getType() == LINK_DOCUMENT) { // internal
+            if (hyperlink.getTypeEnum() == HyperlinkType.DOCUMENT) { // internal
                 navigateTo(cell, spreadsheet, hyperlink.getAddress());
             } else {
                 spreadsheet.getUI().getPage()
@@ -162,7 +164,7 @@ public class DefaultHyperlinkCellClickHandler implements
      * @return True if hyperlink is found
      */
     public final static boolean isHyperlinkFormulaCell(Cell cell) {
-        return cell != null && cell.getCellType() == Cell.CELL_TYPE_FORMULA
+        return cell != null && cell.getCellTypeEnum() == CellType.FORMULA
                 && cell.getCellFormula().startsWith("HYPERLINK(");
     }
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/DefaultHyperlinkCellClickHandler.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/DefaultHyperlinkCellClickHandler.java
@@ -17,7 +17,6 @@ package com.vaadin.addon.spreadsheet;
  * #L%
  */
 
-import static org.apache.poi.common.usermodel.Hyperlink.LINK_DOCUMENT;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/HSSFColorConverter.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/HSSFColorConverter.java
@@ -21,6 +21,7 @@ import org.apache.poi.hssf.usermodel.HSSFCellStyle;
 import org.apache.poi.hssf.usermodel.HSSFPalette;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.hssf.util.HSSFColor;
+import org.apache.poi.hssf.util.HSSFColor.HSSFColorPredefined;
 import org.apache.poi.ss.usermodel.BorderFormatting;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.ConditionalFormattingRule;
@@ -40,7 +41,7 @@ public class HSSFColorConverter implements ColorConverter {
     private String defaultBackgroundColor;
     private String defaultColor;
 
-    private static final HSSFColor HSSF_AUTO = new HSSFColor.AUTOMATIC();
+    private static final HSSFColor HSSF_AUTO = HSSFColorPredefined.AUTOMATIC.getColor();
 
     public HSSFColorConverter(HSSFWorkbook wb) {
         this.wb = wb;
@@ -87,13 +88,13 @@ public class HSSFColorConverter implements ColorConverter {
         String backgroundColor = null;
         HSSFColor fillForegroundColorColor = cs.getFillForegroundColorColor();
         if (fillForegroundColorColor != null
-                && fillForegroundColor != HSSFColor.AUTOMATIC.index) {
+                && fillForegroundColor != HSSFColorPredefined.AUTOMATIC.getColor().getIndex()) {
             backgroundColor = styleColor(fillForegroundColor);
         } else {
             HSSFColor fillBackgroundColorColor = cs
                     .getFillBackgroundColorColor();
             if (fillBackgroundColorColor != null
-                    && fillBackgroundColor != HSSFColor.AUTOMATIC.index) {
+                    && fillBackgroundColor != HSSFColorPredefined.AUTOMATIC.getColor().getIndex()) {
                 backgroundColor = styleColor(fillBackgroundColor);
             }
         }
@@ -136,13 +137,13 @@ public class HSSFColorConverter implements ColorConverter {
 
         HSSFColor fillForegroundColorColor = cs.getFillForegroundColorColor();
         if (fillForegroundColorColor != null
-                && fillForegroundColor != HSSFColor.AUTOMATIC.index) {
+                && fillForegroundColor != HSSFColorPredefined.AUTOMATIC.getColor().getIndex()) {
             return true;
         } else {
             HSSFColor fillBackgroundColorColor = cs
                     .getFillBackgroundColorColor();
             if (fillBackgroundColorColor != null
-                    && fillBackgroundColor != HSSFColor.AUTOMATIC.index) {
+                    && fillBackgroundColor != HSSFColorPredefined.AUTOMATIC.getColor().getIndex()) {
                 return true;
             }
         }

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/HSSFColorConverter.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/HSSFColorConverter.java
@@ -21,7 +21,6 @@ import org.apache.poi.hssf.usermodel.HSSFCellStyle;
 import org.apache.poi.hssf.usermodel.HSSFPalette;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.hssf.util.HSSFColor;
-import org.apache.poi.hssf.util.HSSFColor.HSSFColorPredefined;
 import org.apache.poi.ss.usermodel.BorderFormatting;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.ConditionalFormattingRule;
@@ -41,7 +40,7 @@ public class HSSFColorConverter implements ColorConverter {
     private String defaultBackgroundColor;
     private String defaultColor;
 
-    private static final HSSFColor HSSF_AUTO = HSSFColorPredefined.AUTOMATIC.getColor();
+    private static final HSSFColor HSSF_AUTO = new HSSFColor.AUTOMATIC();
 
     public HSSFColorConverter(HSSFWorkbook wb) {
         this.wb = wb;
@@ -88,13 +87,13 @@ public class HSSFColorConverter implements ColorConverter {
         String backgroundColor = null;
         HSSFColor fillForegroundColorColor = cs.getFillForegroundColorColor();
         if (fillForegroundColorColor != null
-                && fillForegroundColor != HSSFColorPredefined.AUTOMATIC.getColor().getIndex()) {
+                && fillForegroundColor != HSSFColor.AUTOMATIC.index) {
             backgroundColor = styleColor(fillForegroundColor);
         } else {
             HSSFColor fillBackgroundColorColor = cs
                     .getFillBackgroundColorColor();
             if (fillBackgroundColorColor != null
-                    && fillBackgroundColor != HSSFColorPredefined.AUTOMATIC.getColor().getIndex()) {
+                    && fillBackgroundColor != HSSFColor.AUTOMATIC.index) {
                 backgroundColor = styleColor(fillBackgroundColor);
             }
         }
@@ -137,13 +136,13 @@ public class HSSFColorConverter implements ColorConverter {
 
         HSSFColor fillForegroundColorColor = cs.getFillForegroundColorColor();
         if (fillForegroundColorColor != null
-                && fillForegroundColor != HSSFColorPredefined.AUTOMATIC.getColor().getIndex()) {
+                && fillForegroundColor != HSSFColor.AUTOMATIC.index) {
             return true;
         } else {
             HSSFColor fillBackgroundColorColor = cs
                     .getFillBackgroundColorColor();
             if (fillBackgroundColorColor != null
-                    && fillBackgroundColor != HSSFColorPredefined.AUTOMATIC.getColor().getIndex()) {
+                    && fillBackgroundColor != HSSFColor.AUTOMATIC.index) {
                 return true;
             }
         }

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SheetOverlayWrapper.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SheetOverlayWrapper.java
@@ -8,7 +8,6 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.util.Units;
 import org.apache.poi.xssf.usermodel.XSSFClientAnchor;
-import org.apache.poi.xssf.usermodel.XSSFShape;
 
 import com.vaadin.addon.spreadsheet.client.OverlayInfo;
 import com.vaadin.server.Resource;
@@ -66,8 +65,9 @@ public abstract class SheetOverlayWrapper implements Serializable {
         int row2 = anchor.getRow2() + 1;
 
         // sanity check
-        if (r2 - r1 < 0 || c2 - c1 < 0)
+        if (r2 - r1 < 0 || c2 - c1 < 0) {
             return false;
+        }
 
         boolean col1isBetweenc1andc2 = c1 <= col1 && col1 <= c2;
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SheetOverlayWrapper.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SheetOverlayWrapper.java
@@ -6,6 +6,7 @@ import org.apache.poi.hssf.converter.ExcelToHtmlUtils;
 import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.util.Units;
 import org.apache.poi.xssf.usermodel.XSSFClientAnchor;
 import org.apache.poi.xssf.usermodel.XSSFShape;
 
@@ -93,7 +94,7 @@ public abstract class SheetOverlayWrapper implements Serializable {
      */
     float getDx1(Sheet sheet) {
         if (anchor instanceof XSSFClientAnchor) {
-            return anchor.getDx1() / XSSFShape.EMU_PER_PIXEL;
+            return anchor.getDx1() / Units.EMU_PER_PIXEL;
         } else {
             return ExcelToHtmlUtils.getColumnWidthInPx(sheet
                     .getColumnWidth(anchor.getCol1())) * anchor.getDx1() / 1023;
@@ -110,7 +111,7 @@ public abstract class SheetOverlayWrapper implements Serializable {
      */
     private float getDx2(Sheet sheet) {
         if (anchor instanceof XSSFClientAnchor) {
-            return anchor.getDx2() / XSSFShape.EMU_PER_PIXEL;
+            return anchor.getDx2() / Units.EMU_PER_PIXEL;
         } else {
             return ExcelToHtmlUtils.getColumnWidthInPx(sheet
                     .getColumnWidth(anchor.getCol2())) * anchor.getDx2() / 1023;
@@ -127,7 +128,7 @@ public abstract class SheetOverlayWrapper implements Serializable {
      */
     float getDy1(Sheet sheet) {
         if (anchor instanceof XSSFClientAnchor) {
-            return anchor.getDy1() / XSSFShape.EMU_PER_POINT;
+            return anchor.getDy1() / Units.EMU_PER_POINT;
         } else {
             Row row = sheet.getRow(anchor.getRow1());
             return (row == null ? sheet.getDefaultRowHeightInPoints() : row
@@ -145,7 +146,7 @@ public abstract class SheetOverlayWrapper implements Serializable {
      */
     private float getDy2(Sheet sheet) {
         if (anchor instanceof XSSFClientAnchor) {
-            return anchor.getDy2() / XSSFShape.EMU_PER_POINT;
+            return anchor.getDy2() / Units.EMU_PER_POINT;
         } else {
             Row row = sheet.getRow(anchor.getRow2());
             return (row == null ? sheet.getDefaultRowHeightInPoints() : row

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/Spreadsheet.java
@@ -55,7 +55,6 @@ import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.Hyperlink;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.SheetVisibility;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
@@ -971,19 +970,10 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
      *             If the index or state is invalid, or if trying to hide the
      *             only visible sheet.
      */
-    public void setSheetHidden(int sheetPOIIndex, int hidden) {
-    	setSheetHidden(sheetPOIIndex, SheetVisibility.values()[hidden]);
-    }
-    
-    /**
-     * @param sheetPOIIndex
-     * @param visibility
-     * @throws IllegalArgumentException
-     */
-    public void setSheetHidden(int sheetPOIIndex, SheetVisibility visibility)
+    public void setSheetHidden(int sheetPOIIndex, int hidden)
             throws IllegalArgumentException {
         // POI allows user to hide all sheets ...
-        if (visibility != SheetVisibility.VISIBLE
+        if (hidden != 0
                 && SpreadsheetUtil.getNumberOfVisibleSheets(workbook) == 1
                 && !workbook.isSheetHidden(sheetPOIIndex)) {
             throw new IllegalArgumentException(
@@ -992,17 +982,17 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
         boolean isHidden = workbook.isSheetHidden(sheetPOIIndex);
         boolean isVeryHidden = workbook.isSheetVeryHidden(sheetPOIIndex);
         int activeSheetIndex = workbook.getActiveSheetIndex();
-        workbook.setSheetVisibility(sheetPOIIndex, visibility);
+        workbook.setSheetHidden(sheetPOIIndex, hidden);
 
         // skip component reload if "nothing changed"
-        if (visibility == SheetVisibility.VISIBLE && (isHidden || isVeryHidden) || visibility != SheetVisibility.VISIBLE
+        if (hidden == 0 && (isHidden || isVeryHidden) || hidden != 0
                 && !(isHidden && isVeryHidden)) {
             if (sheetPOIIndex != activeSheetIndex) {
                 reloadSheetNames();
                 getState().sheetIndex = getSpreadsheetSheetIndex(activeSheetIndex) + 1;
             } else { // the active sheet can be only set as hidden
                 int oldVisibleSheetIndex = getState().sheetIndex - 1;
-                if (visibility != SheetVisibility.VISIBLE
+                if (hidden != 0
                         && activeSheetIndex == (workbook.getNumberOfSheets() - 1)) {
                     // hiding the active sheet, and it was the last sheet
                     oldVisibleSheetIndex--;

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/Spreadsheet.java
@@ -48,13 +48,16 @@ import org.apache.poi.hssf.converter.AbstractExcelUtils;
 import org.apache.poi.hssf.usermodel.HSSFSheet;
 import org.apache.poi.hssf.usermodel.HSSFWorkbook;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.FormulaEvaluator;
 import org.apache.poi.ss.usermodel.Hyperlink;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.SheetVisibility;
 import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellRangeUtil;
 import org.apache.poi.ss.util.CellReference;
@@ -968,10 +971,19 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
      *             If the index or state is invalid, or if trying to hide the
      *             only visible sheet.
      */
-    public void setSheetHidden(int sheetPOIIndex, int hidden)
+    public void setSheetHidden(int sheetPOIIndex, int hidden) {
+    	setSheetHidden(sheetPOIIndex, SheetVisibility.values()[hidden]);
+    }
+    
+    /**
+     * @param sheetPOIIndex
+     * @param visibility
+     * @throws IllegalArgumentException
+     */
+    public void setSheetHidden(int sheetPOIIndex, SheetVisibility visibility)
             throws IllegalArgumentException {
         // POI allows user to hide all sheets ...
-        if (hidden != 0
+        if (visibility != SheetVisibility.VISIBLE
                 && SpreadsheetUtil.getNumberOfVisibleSheets(workbook) == 1
                 && !workbook.isSheetHidden(sheetPOIIndex)) {
             throw new IllegalArgumentException(
@@ -980,17 +992,17 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
         boolean isHidden = workbook.isSheetHidden(sheetPOIIndex);
         boolean isVeryHidden = workbook.isSheetVeryHidden(sheetPOIIndex);
         int activeSheetIndex = workbook.getActiveSheetIndex();
-        workbook.setSheetHidden(sheetPOIIndex, hidden);
+        workbook.setSheetVisibility(sheetPOIIndex, visibility);
 
         // skip component reload if "nothing changed"
-        if (hidden == 0 && (isHidden || isVeryHidden) || hidden != 0
+        if (visibility == SheetVisibility.VISIBLE && (isHidden || isVeryHidden) || visibility != SheetVisibility.VISIBLE
                 && !(isHidden && isVeryHidden)) {
             if (sheetPOIIndex != activeSheetIndex) {
                 reloadSheetNames();
                 getState().sheetIndex = getSpreadsheetSheetIndex(activeSheetIndex) + 1;
             } else { // the active sheet can be only set as hidden
                 int oldVisibleSheetIndex = getState().sheetIndex - 1;
-                if (hidden != 0
+                if (visibility != SheetVisibility.VISIBLE
                         && activeSheetIndex == (workbook.getNumberOfSheets() - 1)) {
                     // hiding the active sheet, and it was the last sheet
                     oldVisibleSheetIndex--;
@@ -1623,11 +1635,11 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
         }
         Cell cell = r.getCell(col);
         if (cell == null) {
-            cell = r.createCell(col, Cell.CELL_TYPE_FORMULA);
+            cell = r.createCell(col, CellType.FORMULA);
         } else {
             final String key = SpreadsheetUtil.toKey(col + 1, row + 1);
             valueManager.clearCellCache(key);
-            cell.setCellType(Cell.CELL_TYPE_FORMULA);
+            cell.setCellType(CellType.FORMULA);
         }
         cell.setCellFormula(formula);
         valueManager.cellUpdated(cell);
@@ -2159,7 +2171,7 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
                 for (short c = row.getFirstCellNum(); c < row.getLastCellNum(); c++) {
                     Cell cell = row.getCell(c);
                     if (cell != null
-                            && cell.getCellType() != Cell.CELL_TYPE_BLANK) {
+                            && cell.getCellTypeEnum() != CellType.BLANK) {
                         return r;
                     }
                 }
@@ -3496,7 +3508,7 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
                 // shifting etc.) from merged cell into basic or vice versa.
                 if (region == null || region.col1 == c_one_based
                         && region.row1 == row_one_based) {
-                    Comment comment = sheet.getCellComment(r, c);
+                    Comment comment = sheet.getCellComment(new CellAddress(r, c));
                     String key = SpreadsheetUtil.toKey(c_one_based,
                             row_one_based);
                     if (comment != null) {

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetHandlerImpl.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetHandlerImpl.java
@@ -1,5 +1,25 @@
 package com.vaadin.addon.spreadsheet;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.util.CellAddress;
+import org.apache.poi.ss.util.CellRangeAddress;
+import org.apache.poi.ss.util.CellReference;
+
 /*
  * #%L
  * Vaadin Spreadsheet
@@ -21,23 +41,6 @@ import com.vaadin.addon.spreadsheet.Spreadsheet.CellValueChangeEvent;
 import com.vaadin.addon.spreadsheet.Spreadsheet.ProtectedEditEvent;
 import com.vaadin.addon.spreadsheet.client.SpreadsheetServerRpc;
 import com.vaadin.addon.spreadsheet.command.CellValueCommand;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CreationHelper;
-import org.apache.poi.ss.usermodel.RichTextString;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.usermodel.Workbook;
-import org.apache.poi.ss.util.CellRangeAddress;
-import org.apache.poi.ss.util.CellReference;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.StringTokenizer;
 
 /**
  * Implementation of the Spreadsheet Server RPC interface.
@@ -309,13 +312,13 @@ public class SpreadsheetHandlerImpl implements SpreadsheetServerRpc {
                     Double numVal = SpreadsheetUtil.parseNumber(cell,
                             cellContent, spreadsheet.getLocale());
                     if (numVal != null) {
-                        cell.setCellType(Cell.CELL_TYPE_NUMERIC);
+                        cell.setCellType(CellType.NUMERIC);
                         cell.setCellValue(numVal);
                     } else {
                         cell.setCellValue(cellContent);
                     }
                 } else {
-                    cell.setCellType(Cell.CELL_TYPE_BLANK);
+                    cell.setCellType(CellType.BLANK);
                     spreadsheet.markCellAsDeleted(cell, true);
                 }
 
@@ -447,7 +450,7 @@ public class SpreadsheetHandlerImpl implements SpreadsheetServerRpc {
         spreadsheet.getSpreadsheetHistoryManager().addCommand(command);
 
         for (Cell targetCell : targetCells) {
-            targetCell.setCellType(Cell.CELL_TYPE_BLANK);
+            targetCell.setCellType(CellType.BLANK);
             spreadsheet.markCellAsDeleted(targetCell, true);
         }
 
@@ -459,7 +462,7 @@ public class SpreadsheetHandlerImpl implements SpreadsheetServerRpc {
     public void updateCellComment(String text, int col, int row) {
         CreationHelper factory = spreadsheet.getWorkbook().getCreationHelper();
         RichTextString str = factory.createRichTextString(text);
-        spreadsheet.getActiveSheet().getCellComment(row - 1, col - 1)
+        spreadsheet.getActiveSheet().getCellComment(new CellAddress(row - 1, col - 1))
                 .setString(str);
     }
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetHandlerImpl.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetHandlerImpl.java
@@ -1,5 +1,22 @@
 package com.vaadin.addon.spreadsheet;
 
+/*
+ * #%L
+ * Vaadin Spreadsheet
+ * %%
+ * Copyright (C) 2013 - 2015 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Add-On License 3.0
+ * (CVALv3).
+ * 
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ * 
+ * You should have received a copy of the CVALv3 along with this program.
+ * If not, see <http://vaadin.com/license/cval-3>.
+ * #L%
+ */
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -19,23 +36,6 @@ import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellReference;
-
-/*
- * #%L
- * Vaadin Spreadsheet
- * %%
- * Copyright (C) 2013 - 2015 Vaadin Ltd
- * %%
- * This program is available under Commercial Vaadin Add-On License 3.0
- * (CVALv3).
- * 
- * See the file license.html distributed with this software for more
- * information about licensing.
- * 
- * You should have received a copy of the CVALv3 along with this program.
- * If not, see <http://vaadin.com/license/cval-3>.
- * #L%
- */
 
 import com.vaadin.addon.spreadsheet.Spreadsheet.CellValueChangeEvent;
 import com.vaadin.addon.spreadsheet.Spreadsheet.ProtectedEditEvent;

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetStyleFactory.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetStyleFactory.java
@@ -117,9 +117,9 @@ public class SpreadsheetStyleFactory implements Serializable {
     		VerticalAlignment.TOP, "flex-start");
 
     static final Map<org.apache.poi.ss.usermodel.BorderStyle, BorderStyle> BORDER = mapFor(
-    		org.apache.poi.ss.usermodel.BorderStyle.DASH_DOT, BorderStyle.DASHED_THIN, 
-    		org.apache.poi.ss.usermodel.BorderStyle.DASH_DOT_DOT, BorderStyle.DASHED_THIN, 
-    		org.apache.poi.ss.usermodel.BorderStyle.DASHED, BorderStyle.DASHED_THIN,
+            org.apache.poi.ss.usermodel.BorderStyle.DASH_DOT, BorderStyle.DASHED_THIN,
+            org.apache.poi.ss.usermodel.BorderStyle.DASH_DOT_DOT, BorderStyle.DASHED_THIN,
+            org.apache.poi.ss.usermodel.BorderStyle.DASHED, BorderStyle.DASHED_THIN,
             org.apache.poi.ss.usermodel.BorderStyle.DOTTED, BorderStyle.DOTTED_THIN, 
             org.apache.poi.ss.usermodel.BorderStyle.DOUBLE, BorderStyle.DOUBLE, 
             org.apache.poi.ss.usermodel.BorderStyle.HAIR, BorderStyle.SOLID_THIN,
@@ -774,7 +774,7 @@ public class SpreadsheetStyleFactory implements Serializable {
                     cellStyle.getFontIndex());
             defaultFontFamily = styleFontFamily(defaultFont);
             sb.append(defaultFontFamily);
-            if (! defaultFont.getBold() ) {
+            if (defaultFont.getBold()) {
                 sb.append("font-weight:bold;");
             }
             if (defaultFont.getItalic()) {
@@ -804,7 +804,7 @@ public class SpreadsheetStyleFactory implements Serializable {
             if (!fontFamily.equals(defaultFontFamily)) {
                 sb.append(fontFamily);
             }
-            if (! font.getBold()) {
+            if (font.getBold()) {
                 sb.append("font-weight:bold;");
             }
             if (font.getItalic()) {

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetStyleFactory.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetStyleFactory.java
@@ -1,5 +1,22 @@
 package com.vaadin.addon.spreadsheet;
 
+/*
+ * #%L
+ * Vaadin Spreadsheet
+ * %%
+ * Copyright (C) 2013 - 2015 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Add-On License 3.0
+ * (CVALv3).
+ * 
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ * 
+ * You should have received a copy of the CVALv3 along with this program.
+ * If not, see <http://vaadin.com/license/cval-3>.
+ * #L%
+ */
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetStyleFactory.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetStyleFactory.java
@@ -1,46 +1,5 @@
 package com.vaadin.addon.spreadsheet;
 
-/*
- * #%L
- * Vaadin Spreadsheet
- * %%
- * Copyright (C) 2013 - 2015 Vaadin Ltd
- * %%
- * This program is available under Commercial Vaadin Add-On License 3.0
- * (CVALv3).
- * 
- * See the file license.html distributed with this software for more
- * information about licensing.
- * 
- * You should have received a copy of the CVALv3 along with this program.
- * If not, see <http://vaadin.com/license/cval-3>.
- * #L%
- */
-
-import static org.apache.poi.ss.usermodel.CellStyle.ALIGN_CENTER;
-import static org.apache.poi.ss.usermodel.CellStyle.ALIGN_CENTER_SELECTION;
-import static org.apache.poi.ss.usermodel.CellStyle.ALIGN_FILL;
-import static org.apache.poi.ss.usermodel.CellStyle.ALIGN_JUSTIFY;
-import static org.apache.poi.ss.usermodel.CellStyle.ALIGN_LEFT;
-import static org.apache.poi.ss.usermodel.CellStyle.ALIGN_RIGHT;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_DASHED;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_DASH_DOT;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_DASH_DOT_DOT;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_DOTTED;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_DOUBLE;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_HAIR;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_MEDIUM;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_MEDIUM_DASHED;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_MEDIUM_DASH_DOT;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_MEDIUM_DASH_DOT_DOT;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_NONE;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_SLANTED_DASH_DOT;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_THICK;
-import static org.apache.poi.ss.usermodel.CellStyle.BORDER_THIN;
-import static org.apache.poi.ss.usermodel.CellStyle.VERTICAL_BOTTOM;
-import static org.apache.poi.ss.usermodel.CellStyle.VERTICAL_CENTER;
-import static org.apache.poi.ss.usermodel.CellStyle.VERTICAL_TOP;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -56,9 +15,11 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Font;
 import org.apache.poi.ss.usermodel.FontFamily;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.VerticalAlignment;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.xssf.usermodel.XSSFCellStyle;
 import org.apache.poi.xssf.usermodel.XSSFFont;
@@ -130,25 +91,30 @@ public class SpreadsheetStyleFactory implements Serializable {
 
     }
 
-    private static final Map<Short, String> ALIGN = mapFor(ALIGN_LEFT, "left",
-            ALIGN_CENTER, "center", ALIGN_RIGHT, "right", ALIGN_FILL, "left",
-            ALIGN_JUSTIFY, "left", ALIGN_CENTER_SELECTION, "center");
+    private static final Map<HorizontalAlignment, String> ALIGN = mapFor(HorizontalAlignment.LEFT, "left",
+    		HorizontalAlignment.CENTER, "center", HorizontalAlignment.RIGHT, "right", HorizontalAlignment.FILL, "left",
+    		HorizontalAlignment.JUSTIFY, "left", HorizontalAlignment.CENTER_SELECTION, "center");
 
-    private static final Map<Short, String> VERTICAL_ALIGN = mapFor(
-            VERTICAL_BOTTOM, "flex-end", VERTICAL_CENTER, "center",
-            VERTICAL_TOP, "flex-start");
+    private static final Map<VerticalAlignment, String> VERTICAL_ALIGN = mapFor(
+    		VerticalAlignment.BOTTOM, "flex-end", VerticalAlignment.CENTER, "center",
+    		VerticalAlignment.TOP, "flex-start");
 
-    static final Map<Short, BorderStyle> BORDER = mapFor(BORDER_DASH_DOT,
-            BorderStyle.DASHED_THIN, BORDER_DASH_DOT_DOT,
-            BorderStyle.DASHED_THIN, BORDER_DASHED, BorderStyle.DASHED_THIN,
-            BORDER_DOTTED, BorderStyle.DOTTED_THIN, BORDER_DOUBLE,
-            BorderStyle.DOUBLE, BORDER_HAIR, BorderStyle.SOLID_THIN,
-            BORDER_MEDIUM, BorderStyle.SOLID_MEDIUM, BORDER_MEDIUM_DASH_DOT,
-            BorderStyle.DASHED_MEDIUM, BORDER_MEDIUM_DASH_DOT_DOT,
-            BorderStyle.DASHED_MEDIUM, BORDER_MEDIUM_DASHED,
-            BorderStyle.DASHED_MEDIUM, BORDER_NONE, BorderStyle.NONE,
-            BORDER_SLANTED_DASH_DOT, BorderStyle.DASHED_MEDIUM, BORDER_THICK,
-            BorderStyle.SOLID_THICK, BORDER_THIN, BorderStyle.SOLID_THIN);
+    static final Map<org.apache.poi.ss.usermodel.BorderStyle, BorderStyle> BORDER = mapFor(
+    		org.apache.poi.ss.usermodel.BorderStyle.DASH_DOT, BorderStyle.DASHED_THIN, 
+    		org.apache.poi.ss.usermodel.BorderStyle.DASH_DOT_DOT, BorderStyle.DASHED_THIN, 
+    		org.apache.poi.ss.usermodel.BorderStyle.DASHED, BorderStyle.DASHED_THIN,
+            org.apache.poi.ss.usermodel.BorderStyle.DOTTED, BorderStyle.DOTTED_THIN, 
+            org.apache.poi.ss.usermodel.BorderStyle.DOUBLE, BorderStyle.DOUBLE, 
+            org.apache.poi.ss.usermodel.BorderStyle.HAIR, BorderStyle.SOLID_THIN,
+            org.apache.poi.ss.usermodel.BorderStyle.MEDIUM, BorderStyle.SOLID_MEDIUM, 
+            org.apache.poi.ss.usermodel.BorderStyle.MEDIUM_DASH_DOT, BorderStyle.DASHED_MEDIUM, 
+            org.apache.poi.ss.usermodel.BorderStyle.MEDIUM_DASH_DOT_DOT, BorderStyle.DASHED_MEDIUM, 
+            org.apache.poi.ss.usermodel.BorderStyle.MEDIUM_DASHED, BorderStyle.DASHED_MEDIUM, 
+            org.apache.poi.ss.usermodel.BorderStyle.NONE, BorderStyle.NONE,
+            null, BorderStyle.NONE,
+            org.apache.poi.ss.usermodel.BorderStyle.SLANTED_DASH_DOT, BorderStyle.DASHED_MEDIUM, 
+            org.apache.poi.ss.usermodel.BorderStyle.THICK, BorderStyle.SOLID_THICK, 
+            org.apache.poi.ss.usermodel.BorderStyle.THIN, BorderStyle.SOLID_THIN);
 
     /** CellStyle index to selector + style map */
     private final HashMap<Integer, String> shiftedBorderTopStyles = new HashMap<Integer, String>();
@@ -175,7 +141,7 @@ public class SpreadsheetStyleFactory implements Serializable {
 
     private Font defaultFont;
 
-    private short defaultTextAlign;
+    private HorizontalAlignment defaultTextAlign;
 
     private short defaultFontHeightInPoints;
 
@@ -209,7 +175,7 @@ public class SpreadsheetStyleFactory implements Serializable {
 
         // get default text alignments
         CellStyle cellStyle = workbook.getCellStyleAt((short) 0);
-        defaultTextAlign = cellStyle.getAlignment();
+        defaultTextAlign = cellStyle.getAlignmentEnum();
         // defaultVerticalAlign = cellStyle.getVerticalAlignment();
 
         // create default style (cell style 0)
@@ -593,8 +559,8 @@ public class SpreadsheetStyleFactory implements Serializable {
         fontStyle(sb, cellStyle);
         colorConverter.colorStyles(cellStyle, sb);
         borderStyles(sb, cellStyle);
-        if (cellStyle.getAlignment() != defaultTextAlign) {
-            styleOut(sb, "text-align", cellStyle.getAlignment(), ALIGN);
+        if (cellStyle.getAlignmentEnum() != defaultTextAlign) {
+            styleOut(sb, "text-align", cellStyle.getAlignmentEnum(), ALIGN);
             // TODO For correct overflow, rtl should be used for right align
             // if (cellStyle.getAlignment() == ALIGN_RIGHT) {
             // sb.append("direction:rtl;");
@@ -604,7 +570,7 @@ public class SpreadsheetStyleFactory implements Serializable {
         // excel default is bottom, so that is what we have in the CSS base
         // files.
         // TODO This only works on modern (10+) IE.
-        styleOut(sb, "justify-content", cellStyle.getVerticalAlignment(),
+        styleOut(sb, "justify-content", cellStyle.getVerticalAlignmentEnum(),
                 VERTICAL_ALIGN);
 
         if (cellStyle.getWrapText()) { // default is to overflow
@@ -791,10 +757,8 @@ public class SpreadsheetStyleFactory implements Serializable {
                     cellStyle.getFontIndex());
             defaultFontFamily = styleFontFamily(defaultFont);
             sb.append(defaultFontFamily);
-            if (defaultFont.getBoldweight() != Font.BOLDWEIGHT_NORMAL) {
-                sb.append("font-weight:");
-                sb.append(defaultFont.getBoldweight());
-                sb.append(";");
+            if (! defaultFont.getBold() ) {
+                sb.append("font-weight:bold;");
             }
             if (defaultFont.getItalic()) {
                 sb.append("font-style:italic;");
@@ -823,10 +787,8 @@ public class SpreadsheetStyleFactory implements Serializable {
             if (!fontFamily.equals(defaultFontFamily)) {
                 sb.append(fontFamily);
             }
-            if (font.getBoldweight() != Font.BOLDWEIGHT_NORMAL) {
-                sb.append("font-weight:");
-                sb.append(font.getBoldweight());
-                sb.append(";");
+            if (! font.getBold()) {
+                sb.append("font-weight:bold;");
             }
             if (font.getItalic()) {
                 sb.append("font-style:italic;");
@@ -894,7 +856,7 @@ public class SpreadsheetStyleFactory implements Serializable {
 
     private String getBorderRightStyle(CellStyle cellStyle) {
         StringBuilder sb = new StringBuilder();
-        BorderStyle borderRight = BORDER.get(cellStyle.getBorderRight());
+        BorderStyle borderRight = BORDER.get(cellStyle.getBorderRightEnum());
         if (cellStyle instanceof XSSFCellStyle
                 && !((XSSFCellStyle) cellStyle).getCoreXf().getApplyBorder()) {
             // borders from theme are not working in POI 3.9
@@ -907,7 +869,7 @@ public class SpreadsheetStyleFactory implements Serializable {
                         .getStyle() : null;
                 if (ptrn != null) {
                     Short key = (short) (ptrn.intValue() - 1);
-                    borderRight = BORDER.get(key);
+                    borderRight = BORDER.get(org.apache.poi.ss.usermodel.BorderStyle.valueOf(key));
                 }
             }
         }
@@ -922,7 +884,7 @@ public class SpreadsheetStyleFactory implements Serializable {
 
     private String getBorderBottomStyle(CellStyle cellStyle) {
         StringBuilder sb = new StringBuilder();
-        BorderStyle borderBottom = BORDER.get(cellStyle.getBorderBottom());
+        BorderStyle borderBottom = BORDER.get(cellStyle.getBorderBottomEnum());
         if (cellStyle instanceof XSSFCellStyle
                 && !((XSSFCellStyle) cellStyle).getCoreXf().getApplyBorder()) {
             // borders from theme are not working in POI 3.9
@@ -935,7 +897,7 @@ public class SpreadsheetStyleFactory implements Serializable {
                         .getStyle() : null;
                 if (ptrn != null) {
                     Short key = (short) (ptrn.intValue() - 1);
-                    borderBottom = BORDER.get(key);
+                    borderBottom = BORDER.get(org.apache.poi.ss.usermodel.BorderStyle.valueOf(key));
                 }
             }
         }
@@ -950,10 +912,10 @@ public class SpreadsheetStyleFactory implements Serializable {
 
     private void borderStyles(StringBuilder sb, CellStyle cellStyle) {
 
-        BorderStyle borderLeft = BORDER.get(cellStyle.getBorderLeft());
-        BorderStyle borderRight = BORDER.get(cellStyle.getBorderRight());
-        BorderStyle borderTop = BORDER.get(cellStyle.getBorderTop());
-        BorderStyle borderBottom = BORDER.get(cellStyle.getBorderBottom());
+        BorderStyle borderLeft = BORDER.get(cellStyle.getBorderLeftEnum());
+        BorderStyle borderRight = BORDER.get(cellStyle.getBorderRightEnum());
+        BorderStyle borderTop = BORDER.get(cellStyle.getBorderTopEnum());
+        BorderStyle borderBottom = BORDER.get(cellStyle.getBorderBottomEnum());
 
         if (cellStyle instanceof XSSFCellStyle
                 && !((XSSFCellStyle) cellStyle).getCoreXf().getApplyBorder()) {
@@ -968,7 +930,7 @@ public class SpreadsheetStyleFactory implements Serializable {
                         .getStyle() : null;
                 if (ptrn != null) {
                     Short key = (short) (ptrn.intValue() - 1);
-                    borderLeft = BORDER.get(key);
+                    borderLeft = BORDER.get(org.apache.poi.ss.usermodel.BorderStyle.valueOf(key));
                 }
             }
             if (borderRight == BorderStyle.NONE) {
@@ -976,7 +938,7 @@ public class SpreadsheetStyleFactory implements Serializable {
                         .getStyle() : null;
                 if (ptrn != null) {
                     Short key = (short) (ptrn.intValue() - 1);
-                    borderRight = BORDER.get(key);
+                    borderRight = BORDER.get(org.apache.poi.ss.usermodel.BorderStyle.valueOf(key));
                 }
             }
             if (borderBottom == BorderStyle.NONE) {
@@ -984,7 +946,7 @@ public class SpreadsheetStyleFactory implements Serializable {
                         .getStyle() : null;
                 if (ptrn != null) {
                     Short key = (short) (ptrn.intValue() - 1);
-                    borderBottom = BORDER.get(key);
+                    borderBottom = BORDER.get(org.apache.poi.ss.usermodel.BorderStyle.valueOf(key));
                 }
             }
             if (borderTop == BorderStyle.NONE) {
@@ -992,7 +954,7 @@ public class SpreadsheetStyleFactory implements Serializable {
                         .getStyle() : null;
                 if (ptrn != null) {
                     Short key = (short) (ptrn.intValue() - 1);
-                    borderTop = BORDER.get(key);
+                    borderTop = BORDER.get(org.apache.poi.ss.usermodel.BorderStyle.valueOf(key));
                 }
 
             }

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetUtil.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetUtil.java
@@ -30,6 +30,7 @@ import java.util.regex.Pattern;
 
 import org.apache.poi.hssf.converter.ExcelToHtmlUtils;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.DateUtil;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -90,7 +91,7 @@ public class SpreadsheetUtil implements Serializable {
      * @return true if the cell contains a date
      */
     public static boolean cellContainsDate(Cell cell) {
-        return cell.getCellType() == Cell.CELL_TYPE_NUMERIC
+        return cell.getCellTypeEnum() == CellType.NUMERIC
                 && DateUtil.isCellDateFormatted(cell);
     }
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetUtil.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetUtil.java
@@ -414,7 +414,7 @@ public class SpreadsheetUtil implements Serializable {
      *         every string.
      */
     public static boolean needsLeadingQuote(Cell cell) {
-        if (cell.getCellType() != Cell.CELL_TYPE_STRING) {
+        if (cell.getCellTypeEnum() != CellType.STRING) {
             return false;
         }
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/action/EditCellCommentAction.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/action/EditCellCommentAction.java
@@ -18,6 +18,7 @@ package com.vaadin.addon.spreadsheet.action;
  */
 
 import org.apache.poi.ss.usermodel.Comment;
+import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellReference;
 
@@ -45,7 +46,7 @@ public class EditCellCommentAction extends SpreadsheetAction {
                     && event.getIndividualSelectedCells().size() == 0) {
                 CellReference cr = event.getSelectedCellReference();
                 Comment cellComment = spreadsheet.getActiveSheet()
-                        .getCellComment(cr.getRow(), cr.getCol());
+                        .getCellComment(new CellAddress(cr.getRow(), cr.getCol()));
                 if (cellComment != null) {
                     return true;
                 }

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/action/InsertDeleteCellCommentAction.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/action/InsertDeleteCellCommentAction.java
@@ -25,6 +25,7 @@ import org.apache.poi.ss.usermodel.Drawing;
 import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellReference;
 
@@ -52,7 +53,7 @@ public class InsertDeleteCellCommentAction extends SpreadsheetAction {
                     && event.getIndividualSelectedCells().size() == 0) {
                 CellReference cr = event.getSelectedCellReference();
                 Comment cellComment = spreadsheet.getActiveSheet()
-                        .getCellComment(cr.getRow(), cr.getCol());
+                        .getCellComment(new CellAddress(cr.getRow(), cr.getCol()));
                 if (cellComment == null) {
                     setCaption("Insert comment");
                 } else {

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/action/ShowHideCellCommentAction.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/action/ShowHideCellCommentAction.java
@@ -21,6 +21,7 @@ import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellReference;
 
@@ -48,7 +49,7 @@ public class ShowHideCellCommentAction extends SpreadsheetAction {
                     && event.getIndividualSelectedCells().size() == 0) {
                 CellReference cr = event.getSelectedCellReference();
                 Comment cellComment = spreadsheet.getActiveSheet()
-                        .getCellComment(cr.getRow(), cr.getCol());
+                        .getCellComment(new CellAddress(cr.getRow(), cr.getCol()));
                 if (cellComment != null) {
                     if (cellComment.isVisible()) {
                         setCaption("Hide comment");
@@ -73,7 +74,7 @@ public class ShowHideCellCommentAction extends SpreadsheetAction {
                                          SelectionChangeEvent event) {
         CellReference cr = event.getSelectedCellReference();
         Comment cellComment = spreadsheet.getActiveSheet().getCellComment(
-                cr.getRow(), cr.getCol());
+        		new CellAddress(cr.getRow(), cr.getCol()));
         cellComment.setVisible(!cellComment.isVisible());
         Sheet sheet = spreadsheet.getActiveSheet();
         Row row = sheet.getRow(cr.getRow());

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/CellValueCommand.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/CellValueCommand.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.apache.poi.ss.formula.FormulaParseException;
 import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellReference;

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/CellValueCommand.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/CellValueCommand.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.poi.ss.formula.FormulaParseException;
 import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.ss.util.CellReference;
@@ -299,16 +300,16 @@ public class CellValueCommand extends SpreadsheetCommand implements
         if (cell == null) {
             return null;
         } else {
-            switch (cell.getCellType()) {
-            case Cell.CELL_TYPE_BOOLEAN:
+            switch (cell.getCellTypeEnum()) {
+            case BOOLEAN:
                 return cell.getBooleanCellValue();
-            case Cell.CELL_TYPE_ERROR:
+            case ERROR:
                 return cell.getErrorCellValue();
-            case Cell.CELL_TYPE_FORMULA:
+            case FORMULA:
                 return "=" + cell.getCellFormula();
-            case Cell.CELL_TYPE_NUMERIC:
+            case NUMERIC:
                 return cell.getNumericCellValue();
-            case Cell.CELL_TYPE_STRING:
+            case STRING:
                 return cell.getStringCellValue();
             default:
                 return null;

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/RowData.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/RowData.java
@@ -20,6 +20,7 @@ package com.vaadin.addon.spreadsheet.command;
 import com.vaadin.addon.spreadsheet.Spreadsheet;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.ClientAnchor;
 import org.apache.poi.ss.usermodel.Comment;
 import org.apache.poi.ss.usermodel.CreationHelper;
@@ -29,6 +30,7 @@ import org.apache.poi.ss.usermodel.Hyperlink;
 import org.apache.poi.ss.usermodel.RichTextString;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
 
 import java.io.Serializable;
@@ -94,7 +96,7 @@ class RowData implements Serializable {
         }
 
         for(int i = 0; i < maxCol; ++i) {
-            Comment cellComment = row.getSheet().getCellComment(row.getRowNum(), i);
+            Comment cellComment = row.getSheet().getCellComment(new CellAddress(row.getRowNum(), i));
             Cell cell = row.getCell(i);
             if(cellComment != null && cell == null) {
                 CommentData commenData = new CommentData();
@@ -141,7 +143,7 @@ class RowData implements Serializable {
 
         private int columnIndex;
         private int rowIndex;
-        private int cellType;
+        private CellType cellType;
         private String cellFormula;
         private double numericCellValue;
         private Date dateCellValue;
@@ -176,22 +178,23 @@ class RowData implements Serializable {
             }
             hyperlink = cell.getHyperlink();
             cellStyle = cell.getCellStyle();
-            cellType = cell.getCellType();
+            cellType = cell.getCellTypeEnum();
 
             switch (cellType) {
-                case Cell.CELL_TYPE_BLANK:
+            	case _NONE:
+                case BLANK:
                     stringCellValue = cell.getStringCellValue();
                     break;
-                case Cell.CELL_TYPE_BOOLEAN:
+                case BOOLEAN:
                     booleanCellValue = cell.getBooleanCellValue();
                     break;
-                case Cell.CELL_TYPE_ERROR:
+                case ERROR:
                     errorCellValue = cell.getErrorCellValue();
                     break;
-                case Cell.CELL_TYPE_FORMULA:
+                case FORMULA:
                     cellFormula = cell.getCellFormula();
                     break;
-                case Cell.CELL_TYPE_NUMERIC:
+                case NUMERIC:
                     if (DateUtil.isCellDateFormatted(cell)) {
                         if (DateUtil.isCellDateFormatted(cell)) {
                             dateCellValue = cell.getDateCellValue();
@@ -200,7 +203,7 @@ class RowData implements Serializable {
                         numericCellValue = cell.getNumericCellValue();
                     }
                     break;
-                case Cell.CELL_TYPE_STRING:
+                case STRING:
                     richTextCellValue = cell.getRichStringCellValue();
                     break;
             }
@@ -218,26 +221,27 @@ class RowData implements Serializable {
             cell.setCellType(cellType);
 
             switch (cellType) {
-                case Cell.CELL_TYPE_BLANK:
+            	case _NONE:
+                case BLANK:
                     cell.setCellValue(stringCellValue);
                     break;
-                case Cell.CELL_TYPE_BOOLEAN:
+                case BOOLEAN:
                     cell.setCellValue(booleanCellValue);
                     break;
-                case Cell.CELL_TYPE_ERROR:
+                case ERROR:
                     cell.setCellErrorValue(errorCellValue);
                     break;
-                case Cell.CELL_TYPE_FORMULA:
+                case FORMULA:
                     cell.setCellFormula(cellFormula);
                     break;
-                case Cell.CELL_TYPE_NUMERIC:
+                case NUMERIC:
                     if(dateCellValue != null) {
                         cell.setCellValue(dateCellValue);
                     } else {
                         cell.setCellValue(numericCellValue);
                     }
                     break;
-                case Cell.CELL_TYPE_STRING:
+                case STRING:
                     cell.setCellValue(richTextCellValue);
                     break;
             }
@@ -265,7 +269,7 @@ class RowData implements Serializable {
         }
 
         public void writeTo(Cell cell) {
-            Drawing drawingPatriarch = cell.getSheet().createDrawingPatriarch();
+            Drawing<?> drawingPatriarch = cell.getSheet().createDrawingPatriarch();
             CreationHelper factory = cell.getSheet().getWorkbook().getCreationHelper();
 
             Comment newCellComment = drawingPatriarch.createCellComment(clientAnchor);

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/RowData.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/RowData.java
@@ -1,5 +1,22 @@
 package com.vaadin.addon.spreadsheet.command;
 
+/*
+ * #%L
+ * Vaadin Spreadsheet
+ * %%
+ * Copyright (C) 2013 - 2015 Vaadin Ltd
+ * %%
+ * This program is available under Commercial Vaadin Add-On License 3.0
+ * (CVALv3).
+ * 
+ * See the file license.html distributed with this software for more
+ * information about licensing.
+ * 
+ * You should have received a copy of the CVALv3 along with this program.
+ * If not, see <http://vaadin.com/license/cval-3>.
+ * #L%
+ */
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -19,23 +36,6 @@ import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellAddress;
 import org.apache.poi.ss.util.CellRangeAddress;
-
-/*
- * #%L
- * Vaadin Spreadsheet
- * %%
- * Copyright (C) 2013 - 2015 Vaadin Ltd
- * %%
- * This program is available under Commercial Vaadin Add-On License 3.0
- * (CVALv3).
- * 
- * See the file license.html distributed with this software for more
- * information about licensing.
- * 
- * You should have received a copy of the CVALv3 along with this program.
- * If not, see <http://vaadin.com/license/cval-3>.
- * #L%
- */
 
 import com.vaadin.addon.spreadsheet.Spreadsheet;
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/RowData.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/command/RowData.java
@@ -1,5 +1,25 @@
 package com.vaadin.addon.spreadsheet.command;
 
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.Comment;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.DateUtil;
+import org.apache.poi.ss.usermodel.Drawing;
+import org.apache.poi.ss.usermodel.Hyperlink;
+import org.apache.poi.ss.usermodel.RichTextString;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.util.CellAddress;
+import org.apache.poi.ss.util.CellRangeAddress;
+
 /*
  * #%L
  * Vaadin Spreadsheet
@@ -18,25 +38,6 @@ package com.vaadin.addon.spreadsheet.command;
  */
 
 import com.vaadin.addon.spreadsheet.Spreadsheet;
-import org.apache.poi.ss.usermodel.Cell;
-import org.apache.poi.ss.usermodel.CellStyle;
-import org.apache.poi.ss.usermodel.CellType;
-import org.apache.poi.ss.usermodel.ClientAnchor;
-import org.apache.poi.ss.usermodel.Comment;
-import org.apache.poi.ss.usermodel.CreationHelper;
-import org.apache.poi.ss.usermodel.DateUtil;
-import org.apache.poi.ss.usermodel.Drawing;
-import org.apache.poi.ss.usermodel.Hyperlink;
-import org.apache.poi.ss.usermodel.RichTextString;
-import org.apache.poi.ss.usermodel.Row;
-import org.apache.poi.ss.usermodel.Sheet;
-import org.apache.poi.ss.util.CellAddress;
-import org.apache.poi.ss.util.CellRangeAddress;
-
-import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
 
 /**
  * This class is used to store the data of removed row so that it can be restored. This feature
@@ -60,7 +61,7 @@ class RowData implements Serializable {
     public void copy(int rowIndex) {
         isCopied = true;
         this.rowIndex = rowIndex;
-        this.maxCol = spreadsheet.getLastColumn();
+        maxCol = spreadsheet.getLastColumn();
         cellsData.clear();
         mergedCells.clear();
         commentsWithoutCell.clear();
@@ -269,7 +270,7 @@ class RowData implements Serializable {
         }
 
         public void writeTo(Cell cell) {
-            Drawing<?> drawingPatriarch = cell.getSheet().createDrawingPatriarch();
+            Drawing drawingPatriarch = cell.getSheet().createDrawingPatriarch();
             CreationHelper factory = cell.getSheet().getWorkbook().getCreationHelper();
 
             Comment newCellComment = drawingPatriarch.createCellComment(clientAnchor);

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/demoapps/SpreadsheetDemoUI.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/demoapps/SpreadsheetDemoUI.java
@@ -27,6 +27,7 @@ import java.util.logging.Logger;
 
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.DataFormat;
 import org.apache.poi.ss.usermodel.ExcelStyleDateFormatter;
 import org.apache.poi.ss.usermodel.Row;
@@ -628,7 +629,7 @@ public class SpreadsheetDemoUI extends UI implements Receiver {
             final Sheet sheet = getTestWorkbook().createSheet(
                     "Custom Components");
             Row lastRow = sheet.createRow(100);
-            lastRow.createCell(100, Cell.CELL_TYPE_BOOLEAN).setCellValue(true);
+            lastRow.createCell(100, CellType.BOOLEAN).setCellValue(true);
             sheet.setColumnWidth(0, 6000);
             sheet.setColumnWidth(1, 6000);
             sheet.setColumnWidth(2, 6000);
@@ -646,9 +647,9 @@ public class SpreadsheetDemoUI extends UI implements Receiver {
                     Object value = data[i][j];
                     if (i == 0 || j == 0 || j == 4 || j == 5) {
                         // string cells
-                        cell.setCellType(Cell.CELL_TYPE_STRING);
+                        cell.setCellType(CellType.STRING);
                     } else if (j == 2 || j == 3) {
-                        cell.setCellType(Cell.CELL_TYPE_NUMERIC);
+                        cell.setCellType(CellType.NUMERIC);
                     }
                     final DataFormat format = getTestWorkbook()
                             .createDataFormat();
@@ -796,7 +797,7 @@ public class SpreadsheetDemoUI extends UI implements Receiver {
             }
 
             if (cell != null) {
-                if (cell.getCellType() == Cell.CELL_TYPE_BOOLEAN) {
+                if (cell.getCellTypeEnum() == CellType.BOOLEAN) {
                     ((CheckBox) customEditor).setValue(cell
                             .getBooleanCellValue());
                 } else if (customEditor instanceof DateField) {

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/fixtures/FormatsFixture.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/fixtures/FormatsFixture.java
@@ -67,32 +67,32 @@ public class FormatsFixture implements SpreadsheetFixture {
             c = spreadsheet.createCell(1, column, "example");
             c.setCellStyle(style);
             spreadsheet.createCell(1, column + formats.length + 1,
-                    "" + c.getCellType());
+                    "" + c.getCellTypeEnum().ordinal());
 
             c = spreadsheet.createCell(2, column, new Date(1095379000000l));
             c.setCellStyle(style);
             spreadsheet.createCell(2, column + formats.length + 1,
-                    "" + c.getCellType());
+                    "" + c.getCellTypeEnum().ordinal());
 
             c = spreadsheet.createCell(3, column, Boolean.TRUE);
             c.setCellStyle(style);
             spreadsheet.createCell(3, column + formats.length + 1,
-                    "" + c.getCellType());
+                    "" + c.getCellTypeEnum().ordinal());
 
             c = spreadsheet.createCell(4, column, Calendar.getInstance());
             c.setCellStyle(style);
             spreadsheet.createCell(4, column + formats.length + 1,
-                    "" + c.getCellType());
+                    "" + c.getCellTypeEnum().ordinal());
 
             c = spreadsheet.createCell(5, column, Double.parseDouble("3.1415"));
             c.setCellStyle(style);
             spreadsheet.createCell(5, column + formats.length + 1,
-                    "" + c.getCellType());
+                    "" + c.getCellTypeEnum().ordinal());
 
             c = spreadsheet.createCell(6, column, "3.1415");
             c.setCellStyle(style);
             spreadsheet.createCell(6, column + formats.length + 1,
-                    "" + c.getCellType());
+                    "" + c.getCellTypeEnum().ordinal());
         }
 
         int formulaBaseColumn = 0;
@@ -116,7 +116,7 @@ public class FormatsFixture implements SpreadsheetFixture {
             // sheetController.setCellType(Cell.CELL_TYPE_FORMULA);
             c.setCellFormula(formula);
             c = spreadsheet.createCell(row, formulaBaseColumn + 2,
-                    c.getCellType());
+                    c.getCellTypeEnum().ordinal());
         }
 
         spreadsheet.refreshAllCellValues();

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/fixtures/HyperLinkFixture.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/fixtures/HyperLinkFixture.java
@@ -1,5 +1,6 @@
 package com.vaadin.addon.spreadsheet.test.fixtures;
 
+import org.apache.poi.common.usermodel.HyperlinkType;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CreationHelper;
 import org.apache.poi.ss.usermodel.Hyperlink;
@@ -40,12 +41,12 @@ public class HyperLinkFixture implements SpreadsheetFixture {
         cell = spreadsheet.createCell(2, 1, "file link");
         sheet = cell.getSheet();
         helper = sheet.getWorkbook().getCreationHelper();
-        link = helper.createHyperlink(Hyperlink.LINK_FILE);
+        link = helper.createHyperlink(HyperlinkType.FILE);
         link.setAddress("/file-path");
         cell.setHyperlink(link);
 
         cell = spreadsheet.createCell(2, 2, "change me");
-        link = helper.createHyperlink(Hyperlink.LINK_DOCUMENT);
+        link = helper.createHyperlink(HyperlinkType.DOCUMENT);
         ((XSSFHyperlink) link).setTooltip("handled hyperlink");
         cell.setHyperlink(link);
 

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/fixtures/StylesFixture.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/fixtures/StylesFixture.java
@@ -1,8 +1,10 @@
 package com.vaadin.addon.spreadsheet.test.fixtures;
 
+import org.apache.poi.ss.usermodel.BorderStyle;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
 import org.apache.poi.ss.usermodel.Font;
+import org.apache.poi.ss.usermodel.HorizontalAlignment;
 import org.apache.poi.ss.usermodel.IndexedColors;
 import org.apache.poi.ss.usermodel.Workbook;
 
@@ -22,19 +24,19 @@ public class StylesFixture implements SpreadsheetFixture {
 
         c = spreadsheet.createCell(1, 0, "hcenter");
         cellStyle = wb.createCellStyle();
-        cellStyle.setAlignment(CellStyle.ALIGN_CENTER);
+        cellStyle.setAlignment(HorizontalAlignment.CENTER);
         c.setCellStyle(cellStyle);
         sssf.cellStyleUpdated(c, true);
 
         c = spreadsheet.createCell(1, 1, "right align");
         cellStyle = wb.createCellStyle();
-        cellStyle.setAlignment(CellStyle.ALIGN_RIGHT);
+        cellStyle.setAlignment(HorizontalAlignment.RIGHT);
         c.setCellStyle(cellStyle);
         sssf.cellStyleUpdated(c, true);
 
         c = spreadsheet.createCell(2, 0, "blue bottom");
         cellStyle = wb.createCellStyle();
-        cellStyle.setBorderBottom(CellStyle.BORDER_THICK);
+        cellStyle.setBorderBottom(BorderStyle.THICK);
         cellStyle.setBottomBorderColor(IndexedColors.BLUE.getIndex());
         c.setCellStyle(cellStyle);
         sssf.cellStyleUpdated(c, true);
@@ -55,7 +57,7 @@ public class StylesFixture implements SpreadsheetFixture {
 
         c = spreadsheet.createCell(3, 1, "bold text");
         font = wb.createFont();
-        font.setBoldweight(Font.BOLDWEIGHT_BOLD);
+        font.setBold(true);
         cellStyle = wb.createCellStyle();
         cellStyle.setFont(font);
         c.setCellStyle(cellStyle);
@@ -87,14 +89,14 @@ public class StylesFixture implements SpreadsheetFixture {
         c = spreadsheet.createCell(6, 1,
                 "right aligned that should overflow by default to other cells");
         cellStyle = wb.createCellStyle();
-        cellStyle.setAlignment(CellStyle.ALIGN_RIGHT);
+        cellStyle.setAlignment(HorizontalAlignment.RIGHT);
         c.setCellStyle(cellStyle);
         sssf.cellStyleUpdated(c, true);
         c = spreadsheet
                 .createCell(7, 1,
                         "center aligned text that should overflow by default to other cells");
         cellStyle = wb.createCellStyle();
-        cellStyle.setAlignment(CellStyle.ALIGN_CENTER);
+        cellStyle.setAlignment(HorizontalAlignment.CENTER);
         c.setCellStyle(cellStyle);
         sssf.cellStyleUpdated(c, true);
 


### PR DESCRIPTION
Update vaadin-spreadsheet and vaadin-spreadsheet-charts to remove references to deprecated POI objects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet/586)
<!-- Reviewable:end -->
