### PR TITLE
Allows arrow keys to leave cell value editor

### DIFF
--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/FormulaBarWidget.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/FormulaBarWidget.java
@@ -89,6 +89,12 @@ public class FormulaBarWidget extends Composite {
     private boolean editingFormula;
     private boolean enableKeyboardNavigation;
     private TextBox currentEditor;
+    private boolean inlineEdit;
+
+    /**
+     * Input is in full focus when it has been double-clicked or in 'edit' mode.
+     */
+    private boolean inFullFocus;
 
     private SheetInputEventListener sheetInputEventListener;
 
@@ -588,28 +594,28 @@ public class FormulaBarWidget extends Composite {
             break;
 
         case KeyCodes.KEY_UP:
-            if (isEditingFormula() && enableKeyboardNavigation) {
+            if (enableKeyboardNavigation) {
                 moveFormulaCellSelection(event.getShiftKey(), true, false,
                         false);
                 event.preventDefault();
             }
             break;
         case KeyCodes.KEY_RIGHT:
-            if (isEditingFormula() && enableKeyboardNavigation) {
+            if (enableKeyboardNavigation) {
                 moveFormulaCellSelection(event.getShiftKey(), false, true,
                         false);
                 event.preventDefault();
             }
             break;
         case KeyCodes.KEY_DOWN:
-            if (isEditingFormula() && enableKeyboardNavigation) {
+            if (enableKeyboardNavigation) {
                 moveFormulaCellSelection(event.getShiftKey(), false, false,
                         true);
                 event.preventDefault();
             }
             break;
         case KeyCodes.KEY_LEFT:
-            if (isEditingFormula() && enableKeyboardNavigation) {
+            if (enableKeyboardNavigation) {
                 moveFormulaCellSelection(event.getShiftKey(), false, false,
                         false);
                 event.preventDefault();
@@ -633,7 +639,6 @@ public class FormulaBarWidget extends Composite {
         formulaLastKnownPos = -1;
         formulaStartPos = -1;
         clearFormulaSelection();
-
     }
 
     private void checkFormulaEdit(final TextBox editor) {
@@ -653,9 +658,7 @@ public class FormulaBarWidget extends Composite {
 
                         parseAndPaintCellRefs(val);
                         checkForCoordsAtCaret();
-
                     }
-
                 }
             }
         });
@@ -1026,19 +1029,20 @@ public class FormulaBarWidget extends Composite {
      * for the formula.
      */
     public boolean isKeyboardNavigationEnabled() {
-        return enableKeyboardNavigation;
+        return enableKeyboardNavigation && editingFormula;
     }
 
     public void startInlineEdit(boolean inputFullFocus) {
 
-        sheetInputEventListener.setInputFullFocus(inputFullFocus);
+        setInlineEdit(inputFullFocus);
         checkFormulaEdit(inlineEditor);
         updateEditorCaretPos(true);
         checkKeyboardNavigation();
     }
 
     public void stopInlineEdit() {
-        sheetInputEventListener.cellEditingStopped();
+        setInlineEdit(false);
+        setInFullFocus(false);
         stopEditing();
     }
 
@@ -1192,5 +1196,29 @@ public class FormulaBarWidget extends Composite {
     private void setNamedRangeBoxVisible(boolean visible) {
         namedRangeBox.setVisible(visible);
         namedRangeBoxArrow.setVisible(visible);
+    }
+
+    public boolean isInFullFocus() {
+        return inFullFocus;
+    }
+
+    public void setInFullFocus(boolean inFullFocus) {
+        this.inFullFocus = inFullFocus;
+    }
+
+    public boolean isInlineEdit() {
+        return inlineEdit;
+    }
+
+    public void setInlineEdit(boolean inlineEdit) {
+        this.inlineEdit = inlineEdit;
+    }
+
+    public boolean hasLightFocus() {
+        return !inlineEdit
+                || (inlineEdit
+                && !inFullFocus
+                && !editingFormula
+        );
     }
 }

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/SheetInputEventListener.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/SheetInputEventListener.java
@@ -44,12 +44,6 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
 
     private FormulaBarWidget formulaBarWidget;
 
-    /**
-     * Input has full focus only when it has been clicked. Otherwise i.e. arrow
-     * keys change cell selection instead of input caret position.
-     */
-    private boolean inputFullFocus;
-
     public SheetInputEventListener() {
     }
 
@@ -66,14 +60,6 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
         editor.addClickHandler(this);
         editor.addMouseDownHandler(this);
         editor.addMouseUpHandler(this);
-    }
-
-    public void setInputFullFocus(boolean inputFullFocus) {
-        this.inputFullFocus = inputFullFocus;
-    }
-
-    protected void cellEditingStopped() {
-        inputFullFocus = false;
     }
 
     @Override
@@ -97,7 +83,7 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
     @Override
     public void onClick(ClickEvent event) {
         if (widget.isEditingCell()) {
-            inputFullFocus = true;
+            formulaBarWidget.setInlineEdit(true);
         }
         event.stopPropagation();
     }
@@ -131,7 +117,7 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
                 event.preventDefault();
                 break;
             case KeyCodes.KEY_UP:
-                if (!inputFullFocus) {
+                if (formulaBarWidget.hasLightFocus()) {
                     handler.onCellInputEnter(widget.getInlineEditor()
                             .getValue(), true);
                     event.preventDefault();
@@ -142,7 +128,7 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
                 }
                 break;
             case KeyCodes.KEY_DOWN:
-                if (!inputFullFocus) {
+                if (formulaBarWidget.hasLightFocus()) {
                     handler.onCellInputEnter(widget.getInlineEditor()
                             .getValue(), false);
                     event.preventDefault();
@@ -153,7 +139,7 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
                 }
                 break;
             case KeyCodes.KEY_LEFT:
-                if (!inputFullFocus) {
+                if (formulaBarWidget.hasLightFocus()) {
                     handler.onCellInputTab(widget.getInlineEditor().getValue(),
                             true);
                     event.preventDefault();
@@ -161,7 +147,7 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
                     formulaBarWidget.moveFormulaCellSelection(
                             event.isShiftKeyDown(), false, false, false);
                     event.preventDefault();
-                } else if (inputFullFocus) {
+                } else if (formulaBarWidget.isInlineEdit()) {
                     formulaBarWidget.updateEditorCaretPos(true);
                     // prevent scrolling
                     if (widget.getInlineEditor().getCursorPos() == 0) {
@@ -170,7 +156,7 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
                 }
                 break;
             case KeyCodes.KEY_RIGHT:
-                if (!inputFullFocus) {
+                if (formulaBarWidget.hasLightFocus()) {
                     handler.onCellInputTab(widget.getInlineEditor().getValue(),
                             false);
                     event.preventDefault();
@@ -178,7 +164,7 @@ public class SheetInputEventListener implements FocusHandler, KeyPressHandler,
                     formulaBarWidget.moveFormulaCellSelection(
                             event.isShiftKeyDown(), false, true, false);
                     event.preventDefault();
-                } else if (inputFullFocus) {
+                } else if (formulaBarWidget.isInlineEdit()) {
                     formulaBarWidget.updateEditorCaretPos(true);
                     // prevent scrolling
                     int cursorPos = widget.getInlineEditor().getCursorPos();

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/SpreadsheetWidget.java
@@ -1019,6 +1019,7 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
             if (!inlineEditing && !customCellEditorDisplayed) {
                 inlineEditing = true;
                 sheetWidget.startEditingCell(true, true, value);
+                formulaBarWidget.setInFullFocus(true);
                 formulaBarWidget.startInlineEdit(true);
             }
         }
@@ -1177,6 +1178,7 @@ public class SpreadsheetWidget extends Composite implements SheetHandler,
                     inlineEditing = true;
                     sheetWidget.startEditingCell(true, true,
                             formulaBarWidget.getFormulaFieldValue());
+                    formulaBarWidget.setInFullFocus(true);
                     formulaBarWidget.startInlineEdit(true);
                 }
                 break;

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/CellArrowKeyNavigationTest.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/CellArrowKeyNavigationTest.java
@@ -1,0 +1,190 @@
+package com.vaadin.addon.spreadsheet.test;
+
+import com.vaadin.addon.spreadsheet.elements.SheetCellElement;
+import com.vaadin.addon.spreadsheet.elements.SpreadsheetElement;
+import org.junit.Test;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Actions;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Arrow key navigation tests.
+ */
+public class CellArrowKeyNavigationTest extends AbstractSpreadsheetTestCase {
+
+    private SpreadsheetElement spreadSheet;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        headerPage.createNewSpreadsheet();
+        spreadSheet = $(SpreadsheetElement.class).first();
+    }
+
+    @Test
+    public void shouldNotChangeCellWhenEditingAndArrowRightKeyIsPressed() {
+        final SheetCellElement b2 = spreadSheet.getCellAt("B2");
+        b2.setValue("123");
+
+        sheetController.selectCell("B2");
+        new Actions(getDriver()).sendKeys(Keys.F2).build().perform(); //edit mode
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_RIGHT).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B2"));
+    }
+
+    @Test
+    public void shouldNotChangeCellWhenEditingAndArrowLeftKeyIsPressed() {
+        final SheetCellElement b2 = spreadSheet.getCellAt("B2");
+        b2.setValue("123");
+
+        sheetController.selectCell("B2");
+        new Actions(getDriver()).sendKeys(Keys.F2).build().perform(); //edit mode
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_LEFT).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B2"));
+    }
+
+    @Test
+    public void shouldNotChangeCellWhenEditingAndArrowUpKeyIsPressed() {
+        final SheetCellElement b2 = spreadSheet.getCellAt("B2");
+        b2.setValue("123");
+
+        sheetController.selectCell("B2");
+        new Actions(getDriver()).sendKeys(Keys.F2).build().perform(); //edit mode
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_UP).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B2"));
+    }
+
+    @Test
+    public void shouldNotChangeCellWhenEditingAndArrowDownKeyIsPressed() {
+        final SheetCellElement b2 = spreadSheet.getCellAt("B2");
+        b2.setValue("123");
+
+        sheetController.selectCell("B2");
+        new Actions(getDriver()).sendKeys(Keys.F2).build().perform(); //edit mode
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_DOWN).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B2"));
+    }
+
+    @Test
+    public void shouldNotChangeCellWhenDoubleClickEditingAndArrowRightKeyIsPressed() {
+        final SheetCellElement b2 = spreadSheet.getCellAt("B2");
+        b2.setValue("123");
+
+        sheetController.selectCell("A1");
+        sheetController.doubleClickCell("B2"); //edit mode
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_RIGHT).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B2"));
+    }
+
+    @Test
+    public void shouldNotChangeCellWhenDoubleClickEditingAndArrowLeftKeyIsPressed() {
+        final SheetCellElement b2 = spreadSheet.getCellAt("B2");
+        b2.setValue("123");
+
+        sheetController.selectCell("A1");
+        sheetController.doubleClickCell("B2"); //edit mode
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_LEFT).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B2"));
+    }
+
+    @Test
+    public void shouldNotChangeCellWhenDoubleClickEditingAndArrowDownKeyIsPressed() {
+        final SheetCellElement b2 = spreadSheet.getCellAt("B2");
+        b2.setValue("123");
+
+        sheetController.selectCell("A1");
+        sheetController.doubleClickCell("B2"); //edit mode
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_DOWN).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B2"));
+    }
+
+    @Test
+    public void shouldNotChangeCellWhenDoubleClickEditingAndArrowUpKeyIsPressed() {
+        final SheetCellElement b2 = spreadSheet.getCellAt("B2");
+        b2.setValue("123");
+
+        sheetController.selectCell("A1");
+        sheetController.doubleClickCell("B2"); //edit mode
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_UP).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B2"));
+    }
+
+    @Test
+    public void shouldSelectCellToTheRightWhenSingleClickAndArrowRightKeyIsPressed() {
+        sheetController.clickCell("B2");
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD1).build().perform();
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD2).build().perform();
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD3).build().perform();
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_RIGHT).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("C2"));
+    }
+
+    @Test
+    public void shouldSelectCellToTheLeftWhenSingleClickAndArrowLeftKeyIsPressed() {
+        sheetController.clickCell("B2");
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD1).build().perform();
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD2).build().perform();
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD3).build().perform();
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_LEFT).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("A2"));
+    }
+
+    @Test
+    public void shouldSelectCellToTheTopWhenSingleClickAndArrowUpKeyIsPressed() {
+        sheetController.clickCell("B2");
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD1).build().perform();
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD2).build().perform();
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD3).build().perform();
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_UP).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B1"));
+    }
+
+    @Test
+    public void shouldSelectCellToTheBottomWhenSingleClickAndArrowDownKeyIsPressed() {
+        sheetController.clickCell("B2");
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD1).build().perform();
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD2).build().perform();
+        new Actions(getDriver()).sendKeys(Keys.NUMPAD3).build().perform();
+
+        new Actions(getDriver()).sendKeys(Keys.ARROW_DOWN).build().perform();
+
+        String selectedCell = sheetController.getSelectedCell();
+        assertThat(selectedCell, is("B3"));
+    }
+
+}


### PR DESCRIPTION
Selecting a cell via single-clicking or via arrow keys, entering a value by typing, and then using the arrow keys again saves the new value and moves to the appropriate adjacent cell.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet/601)
<!-- Reviewable:end -->
