### PR TITLE
fix for issue #602

### DIFF
--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellValueManager.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellValueManager.java
@@ -661,6 +661,8 @@ public class CellValueManager implements Serializable {
                             spreadsheetLocale);
                     Double numVal = SpreadsheetUtil.parseNumber(cell, value,
                             spreadsheetLocale);
+                    Double dateVal;
+                    Double timeVal;
                     if (value.isEmpty()) {
                         cell.setCellType(CellType.BLANK);
                     } else if (percentage != null) {
@@ -686,6 +688,18 @@ public class CellValueManager implements Serializable {
                     } else if (numVal != null) {
                         cell.setCellType(CellType.NUMERIC);
                         cell.setCellValue(numVal);
+                    } else if ((dateVal = SpreadsheetUtil.parseDate(value,
+                            spreadsheetLocale)) != null) {
+                        cell.setCellType(CellType.NUMERIC);
+                        setCellDataFormat(cell, spreadsheet
+                                .getDefaultDateFormat());
+                        cell.setCellValue(dateVal);
+                    } else if ((timeVal = SpreadsheetUtil.parseTime(value,
+                            spreadsheetLocale)) != null) {
+                        cell.setCellType(CellType.NUMERIC);
+                        setCellDataFormat(cell, spreadsheet
+                                .getDefaultTimeFormat());
+                        cell.setCellValue(timeVal);
                     } else if (oldCellType == CellType.BOOLEAN) {
                         cell.setCellValue(Boolean.parseBoolean(value));
                     } else {
@@ -745,6 +759,26 @@ public class CellValueManager implements Serializable {
 
         if (updateHyperlinks) {
             spreadsheet.loadHyperLinks();
+        }
+    }
+
+    private void setCellDataFormat(Cell cell, String dataFormatString) {
+        Workbook workbook = cell.getSheet().getWorkbook();
+        SpreadsheetStyleFactory styler = spreadsheet
+                .getSpreadsheetStyleFactory();
+        CellStyle cs = cell.getCellStyle();
+        // Do not use default cell style (index == 0) as it will affect all
+        // cells
+        if (cs == null || cs.getIndex() == 0) {
+            cs = workbook.createCellStyle();
+            cell.setCellStyle(cs);
+        }
+        if (cs.getDataFormatString() != null
+                && !cs.getDataFormatString().equals(dataFormatString)) {
+            cs.setDataFormat(workbook
+                    .createDataFormat()
+                    .getFormat(dataFormatString));
+            styler.cellStyleUpdated(cell, true);
         }
     }
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/Spreadsheet.java
@@ -330,6 +330,10 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
 
     private String defaultPercentageFormat = "0.00%";
 
+    private String defaultDateFormat = "d/mm/yyyy";
+
+    private String defaultTimeFormat = "h:mm AM/PM";
+
     protected String initialSheetSelection = null;
 
     private Set<Component> customComponents = new HashSet<Component>();
@@ -4855,6 +4859,50 @@ public class Spreadsheet extends AbstractComponent implements HasComponents,
      */
     public void setDefaultPercentageFormat(String defaultPercentageFormat) {
         this.defaultPercentageFormat = defaultPercentageFormat;
+    }
+
+    /**
+     * Returns the formatting string that is used when a user enters dates
+     * into the spreadsheet.
+     * <p>
+     * Default is "d/mm/yyyy".
+     *
+     * @return The formatting applied to date values when entered by the user
+     */
+    public String getDefaultDateFormat() {
+        return defaultDateFormat;
+    }
+
+    /**
+     * Sets the formatting string that is used when a user enters dates into
+     * the spreadsheet.
+     *
+     * @param defaultDateFormat the new default format
+     */
+    public void setDefaultDateFormat(String defaultDateFormat) {
+        this.defaultDateFormat = defaultDateFormat;
+    }
+
+    /**
+     * Returns the formatting string that is used when a user enters times
+     * into the spreadsheet.
+     * <p>
+     * Default is "h:mm AM/PM".
+     *
+     * @return The formatting applied to time values when entered by the user
+     */
+    public String getDefaultTimeFormat() {
+        return defaultTimeFormat;
+    }
+
+    /**
+     * Sets the formatting string that is used when a user enters times into
+     * the spreadsheet.
+     *
+     * @param defaultTimeFormat the new default format
+     */
+    public void setDefaultTimeFormat(String defaultTimeFormat) {
+        this.defaultTimeFormat = defaultTimeFormat;
     }
 
     /**


### PR DESCRIPTION
- detect date and time values entered by the user and store them as the correct numeric representations

When the user enters a date or a time, instead of being detected and converted/stored as a numeric cell, it is currently just stored as a string. This fix uses a process similar to how percentages are currently handled to detect these values and convert/store them correctly. Doesn't support a huge number of date/time formats, but is a good starting point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet/608)
<!-- Reviewable:end -->
