### PR TITLE
one-line change to allow CSS styling of tabs by name

### DIFF
--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/SheetTabSheet.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/SheetTabSheet.java
@@ -402,6 +402,7 @@ public class SheetTabSheet extends Widget {
         final Element e = Document.get().createDivElement();
         e.setInnerText(tabName);
         e.setClassName("sheet-tabsheet-tab");
+        e.setTitle(tabName);
         return e;
     }
 

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/SheetTabSheet.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/client/SheetTabSheet.java
@@ -240,7 +240,7 @@ public class SheetTabSheet extends Widget {
                             Element element = (Element) tabs.get(
                                     selectedTabIndex).cast();
                             element.getStyle().clearWidth();
-                            element.setInnerText(cachedSheetName);
+                            setTabName(element, cachedSheetName);
                             handler.onSheetRenameCancel();
                             break;
                         default:
@@ -354,16 +354,16 @@ public class SheetTabSheet extends Widget {
             for (int i = 0; i < tabs.length(); i++) {
                 // value cannot be the same as with another sheet
                 if (value.equals(((Element) tabs.get(i).cast()).getInnerText())) {
-                    selectedTab.setInnerText(cachedSheetName);
+                    setTabName(selectedTab, cachedSheetName);
                     return;
                 }
             }
             handler.onSheetRename(selectedTabIndex, value);
-            selectedTab.setInnerText(value);
+            setTabName(selectedTab, value);
             showHideScrollIcons();
         } else {
             // TODO show error ?
-            selectedTab.setInnerText(cachedSheetName);
+            setTabName(selectedTab, cachedSheetName);
         }
     }
 
@@ -400,9 +400,8 @@ public class SheetTabSheet extends Widget {
 
     private Element createTabElement(String tabName) {
         final Element e = Document.get().createDivElement();
-        e.setInnerText(tabName);
+        setTabName(e, tabName);
         e.setClassName("sheet-tabsheet-tab");
-        e.setTitle(tabName);
         return e;
     }
 
@@ -429,7 +428,8 @@ public class SheetTabSheet extends Widget {
         for (int i = 0; i < tabNames.length; i++) {
             JavaScriptObject jso = tabs.get(i);
             if (jso != null) {
-                ((Element) jso.cast()).setInnerText(tabNames[i]);
+                Element tabElement = (Element) jso.cast();
+                setTabName(tabElement, tabNames[i]);
             } else {
                 Element newTab = createTabElement(tabNames[i]);
                 container.appendChild(newTab);
@@ -515,6 +515,17 @@ public class SheetTabSheet extends Widget {
             scrollRight.addClassName(HIDDEN);
             scrollEnd.addClassName(HIDDEN);
         }
+    }
+    
+    /**
+     * Set the tab inner text and title to the given name value
+     * @param tab
+     * @param name to use
+     */
+    private void setTabName(Element tab, String name) {
+        if (tab == null) return;
+        tab.setInnerText(name);
+        tab.setTitle(name);
     }
 
     public void onWidgetResize() {


### PR DESCRIPTION
by adding the tab name as the tooltip (title attribute) (S)CSS can now
be used to style them by name:

.sheet-tabsheet-tab[title~=TAB_NAME] {
...
}

not all attributes work with this CSS syntax, title is the best I've
found.  Plus, for long tab names, like in the "multiple_sheets.xlsx"
test file, the display name is truncated while the tooltip is the full
name, which is nice.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet/700)
<!-- Reviewable:end -->
