### PR TITLE
Explicity import org.apache.poi.ss.formula #645

### DIFF
--- a/vaadin-spreadsheet/pom.xml
+++ b/vaadin-spreadsheet/pom.xml
@@ -128,7 +128,7 @@
                         <Export-Package>com.vaadin.addon.spreadsheet,com.vaadin.addon.spreadsheet.action,com.vaadin.addon.spreadsheet.command</Export-Package>
                         <!-- Ignore GWT stuff, not needed in osgi bundles,
                             GWT compilation seldom happens in such -->
-                        <Import-Package>!com.google.gwt.*,
+                        <Import-Package>!com.google.gwt.*,org.apache.poi.ss.formula,
                             !com.vaadin.client.*, *</Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
Fix for issue #645 
The import org.apache.poi.ss.formula is missing in the manifest. I have added an explicit import into the pom, which allows the spreadsheets.jar to run correctly on an OSGI server (such as Liferay 7.x)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet/703)
<!-- Reviewable:end -->
