### PR TITLE
Delay and avoid expensive createCellDataForCell

### DIFF
--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellValueManager.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellValueManager.java
@@ -1191,30 +1191,28 @@ public class CellValueManager implements Serializable {
                 int columnIndex = cell.getColumnIndex();
                 final String key = SpreadsheetUtil.toKey(columnIndex + 1,
                         rowIndex + 1);
-                CellData cd = createCellDataForCell(cell);
+
                 // update formula cells
                 if (cell.getCellType() == CellType.FORMULA) {
-                    if (cd != null) {
-                        if (sentFormulaCells.contains(key)
-                                || markedCells.contains(key)) {
-                            sentFormulaCells.add(key);
-                            updatedCellData.add(cd);
+                    if (sentFormulaCells.contains(key)
+                            || markedCells.contains(key)) {
+                        CellData cd = createCellDataForCell(cell);
+                        if (cd == null) {
+                            // in case the formula cell value has changed to null or
+                            // empty; this case is probably quite rare, formula cell
+                            // pointing to a cell that was removed or had its value
+                            // cleared ???
+                            cd = new CellData();
+                            cd.col = columnIndex + 1;
+                            cd.row = rowIndex + 1;
+                            cd.cellStyle = "" + cell.getCellStyle().getIndex();
                         }
-                    } else if (sentFormulaCells.contains(key)) {
-                        // in case the formula cell value has changed to null or
-                        // empty; this case is probably quite rare, formula cell
-                        // pointing to a cell that was removed or had its value
-                        // cleared ???
                         sentFormulaCells.add(key);
-                        cd = new CellData();
-                        cd.col = columnIndex + 1;
-                        cd.row = rowIndex + 1;
-                        cd.cellStyle = "" + cell.getCellStyle().getIndex();
                         updatedCellData.add(cd);
                     }
                 } else if (markedCells.contains(key)) {
                     sentCells.add(key);
-                    updatedCellData.add(cd);
+                    updatedCellData.add(createCellDataForCell(cell));
                 }
             }
         }

--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellValueManager.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/CellValueManager.java
@@ -1192,6 +1192,12 @@ public class CellValueManager implements Serializable {
                 final String key = SpreadsheetUtil.toKey(columnIndex + 1,
                         rowIndex + 1);
 
+                // Mark for update if there are formatting rules.
+                if (spreadsheet.getConditionalFormatter()
+                    .getCellFormattingIndex(cell) != null) {
+                    markedCells.add(key);
+                }
+
                 // update formula cells
                 if (cell.getCellType() == CellType.FORMULA) {
                     if (sentFormulaCells.contains(key)


### PR DESCRIPTION
Computing cell data shouldn't be done for all rows as it has a big
performance impact
With this change cell data is only created for sent cells and formulas

This change doesn't prevent the large json in some responses, but it
does prevent the extensive computing time on server-side which was
causing the 5 minutes time to first byte (TTFB) for the server request.
Fixes #713

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/spreadsheet/714)
<!-- Reviewable:end -->
