### PR TITLE
demo: fix java src files and NPI

### DIFF
--- a/flow-demo/pom.xml
+++ b/flow-demo/pom.xml
@@ -121,6 +121,9 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jetty.version}</version>
+                <configuration>
+                    <scanIntervalSeconds>2</scanIntervalSeconds>
+                </configuration>
             </plugin>
 
             <!--

--- a/flow-demo/src/main/java/com/example/application/views/demo/DemoView.java
+++ b/flow-demo/src/main/java/com/example/application/views/demo/DemoView.java
@@ -1,9 +1,14 @@
 package com.example.application.views.demo;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 
 import com.example.application.views.demo.views.BasicFunctionalityExample;
 import com.example.application.views.demo.views.CollaborativeExample;
@@ -16,11 +21,8 @@ import com.example.application.views.demo.views.InlineComponentsExample;
 import com.example.application.views.demo.views.ReportModeExample;
 import com.example.application.views.demo.views.SimpleInvoiceExample;
 import com.example.application.views.main.MainView;
-import org.apache.commons.io.IOUtils;
-
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.Text;
-import com.vaadin.flow.component.dependency.JavaScript;
 import com.vaadin.flow.component.dependency.NpmPackage;
 import com.vaadin.flow.component.html.Div;
 import com.vaadin.flow.component.html.Pre;
@@ -32,7 +34,6 @@ import com.vaadin.flow.router.BeforeEnterEvent;
 import com.vaadin.flow.router.BeforeEnterObserver;
 import com.vaadin.flow.router.HasDynamicTitle;
 import com.vaadin.flow.router.Route;
-import com.vaadin.flow.router.RouteAlias;
 
 @Route(value = "demo/:demoID", layout = MainView.class)
 @NpmPackage(value = "code-prettify", version = "0.1.0")
@@ -105,9 +106,20 @@ public class DemoView extends VerticalLayout implements BeforeEnterObserver, Has
 
     private String getSource(Class clazz) throws IOException {
         InputStream resourceAsStream = clazz.getResourceAsStream(clazz.getSimpleName() + ".java");
-        String code = IOUtils.toString(resourceAsStream);
-        code = code.replace("&", "&amp;").replace("<", "&lt;")
-                .replace(">", "&gt;");
+        
+        String code = "";
+        if (resourceAsStream != null) {
+            code = IOUtils.toString(resourceAsStream);
+        }  else {
+        	File file = new File("./src/main/java/", clazz.getName().replace('.', '/') + ".java");
+        	if (file.canRead()) {
+            	code = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+        	}
+        } 
+        if (code != null) {
+            code = code.replace("&", "&amp;").replace("<", "&lt;")
+                    .replace(">", "&gt;");
+        }
         return code;
     }
 

--- a/flow-demo/src/main/java/com/example/application/views/demoUI/DemoUIView.java
+++ b/flow-demo/src/main/java/com/example/application/views/demoUI/DemoUIView.java
@@ -192,9 +192,10 @@ public class DemoUIView extends VerticalLayout implements Receiver {
         Button freezePanesButton = new Button("Freeze Pane",
                 e->addWindow(new FreezePaneWindow()));
 
-        hideTop = new Checkbox("toggle top bar visibility");
-        hideBottom = new Checkbox("toggle bottom bar visibility");
+        hideTop = new Checkbox("hide top bar visibility");
+        hideBottom = new Checkbox("hide bottom bar visibility");
         hideBoth = new Checkbox("report mode");
+        disableCheckboxes();
 
         hideTop.addValueChangeListener(event -> {
             spreadsheet.setFunctionBarVisible(!hideTop.getValue());
@@ -220,6 +221,7 @@ public class DemoUIView extends VerticalLayout implements Receiver {
                     spreadsheetContainer.remove(spreadsheet);
                     spreadsheet = null;
                     SpreadsheetFactory.logMemoryUsage();
+                    disableCheckboxes();
                 }
         });
 
@@ -319,6 +321,13 @@ public class DemoUIView extends VerticalLayout implements Receiver {
         add(layout);
         layout.add(spreadsheetContainer);
     }
+    
+    private void disableCheckboxes() {
+    	for (Checkbox b : Arrays.asList(hideTop, hideBottom, hideBoth)) {
+    		b.setValue(false);
+    		b.setEnabled(false);
+    	}
+    }
 
     private void addWindow(FreezePaneWindow freezePaneWindow) {
         new Dialog(freezePaneWindow).open();
@@ -399,6 +408,9 @@ public class DemoUIView extends VerticalLayout implements Receiver {
                         gridlines.setValue(spreadsheet.isGridlinesVisible());
                         rowColHeadings.setValue(spreadsheet
                                 .isRowColHeadingsVisible());
+                        hideTop.setEnabled(true);
+                        hideBottom.setEnabled(true);
+                        hideBoth.setEnabled(true);
                 });
     }
 


### PR DESCRIPTION
This fixes two issues
1.- After removing spring, server is unable to find src resources to read .java files for the demo
2.- selecting toggle buttons when spreadsheet was not initialised there were NPE in server

At the same time this configures jetty in dev-mode for reloading when there are changes in code