### PR TITLE
fix: disable charts by default to avoid exception in logs

### DIFF
--- a/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
+++ b/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/Spreadsheet.java
@@ -1130,7 +1130,9 @@ public class Spreadsheet extends Component implements HasComponents, HasSize, Ha
     /** The last visible column in the scroll area **/
     private int lastColumn;
 
-    private boolean chartsEnabled = true;
+    /** Spreadsheet Flow does not support charts yet **/
+    private boolean chartsEnabled = false;
+
     /**
      * This is used for making sure the cells are sent to client side in when
      * the next cell data request comes. This is triggered when the client side


### PR DESCRIPTION
fixes: #738 