### PR TITLE
fix: reconfigure zindex values so as it works with app-layout

### DIFF
--- a/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
+++ b/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/Cell.java
@@ -27,7 +27,7 @@ public class Cell {
 
     public static final String CELL_COMMENT_TRIANGLE_CLASSNAME = "cell-comment-triangle";
     public static final String CELL_INVALID_FORMULA_CLASSNAME = "cell-invalidformula-triangle";
-    private static final int ZINDEXVALUE = 2;
+    private static final int ZINDEXVALUE = 1;
     private final DivElement element;
     private DivElement cellCommentTriangle;
     private DivElement invalidFormulaTriangle;

--- a/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/CellComment.java
+++ b/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/CellComment.java
@@ -76,7 +76,7 @@ public class CellComment extends SpreadsheetOverlay {
         setOwner(owner);
         setAnimationEnabled(false);
         setVisible(false);
-        setZIndex(30);
+        setZIndex(0);
 
         invalidFormula = new VLabel();
         invalidFormula.setVisible(false);
@@ -105,11 +105,11 @@ public class CellComment extends SpreadsheetOverlay {
     }
 
     public void bringForward() {
-        setZIndex(35);
+        setZIndex(1);
     }
 
     public void pushBack() {
-        setZIndex(30);
+        setZIndex(0);
     }
 
     @Override

--- a/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/CopyPasteTextBox.java
+++ b/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/CopyPasteTextBox.java
@@ -80,7 +80,7 @@ public class CopyPasteTextBox extends TextArea implements NativePreviewHandler {
         this.handler = handler;
 
         getElement().getStyle().setPosition(Position.ABSOLUTE);
-        getElement().getStyle().setZIndex(100);
+        getElement().getStyle().setZIndex(1);
         getElement().getStyle().setLeft(-1000, Unit.PX);
 
         // gets round browser security (field must be 'visible' when copying)

--- a/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SelectionWidget.java
+++ b/vaadin-spreadsheet-flow-client/src/main/java/com/vaadin/addon/spreadsheet/client/SelectionWidget.java
@@ -37,7 +37,10 @@ import com.vaadin.client.ui.VOverlay;
 
 public class SelectionWidget extends Composite {
 
+    private static final int ZINDEXVALUE = 2;
+
     private class SelectionOutlineWidget extends Widget {
+
 
         private static final int eventBits = Event.ONMOUSEDOWN
                 | Event.ONMOUSEMOVE | Event.ONMOUSEUP | Event.TOUCHEVENTS
@@ -613,13 +616,13 @@ public class SelectionWidget extends Composite {
         bottomRight = new SelectionOutlineWidget();
         initWidget(bottomRight);
 
-        bottomRight.setZIndex(8);
+        bottomRight.setZIndex(ZINDEXVALUE);
         bottomRight.addStyleName("bottom-right");
         setVisible(false);
 
         paintBottomRight = new PaintOutlineWidget();
         paintBottomRight.addStyleName("bottom-right");
-        paintBottomRight.setZIndex(9);
+        paintBottomRight.setZIndex(ZINDEXVALUE);
 
         Element bottomRightPane = sheetWidget.getBottomRightPane();
         bottomRight.setSheetElement(bottomRightPane);
@@ -632,12 +635,12 @@ public class SelectionWidget extends Composite {
             bottomLeft = new SelectionOutlineWidget();
             bottomLeft.setSheetElement(sheetWidget.getBottomLeftPane());
             bottomLeft.setVisible(false);
-            bottomLeft.setZIndex(18);
+            bottomLeft.setZIndex(ZINDEXVALUE);
             bottomLeft.addStyleName("bottom-left");
             paintBottomLeft = new PaintOutlineWidget();
             paintBottomLeft.setSheetElement(sheetWidget.getBottomLeftPane());
             paintBottomLeft.setVisible(false);
-            paintBottomLeft.setZIndex(19);
+            paintBottomLeft.setZIndex(ZINDEXVALUE);
             paintBottomLeft.addStyleName("bottom-left");
         } else if (horizontalSplitPosition == 0 && bottomLeft != null) {
             bottomLeft.remove();
@@ -655,12 +658,12 @@ public class SelectionWidget extends Composite {
             topRight = new SelectionOutlineWidget();
             topRight.setSheetElement(sheetWidget.getTopRightPane());
             topRight.setVisible(false);
-            topRight.setZIndex(18);
+            topRight.setZIndex(ZINDEXVALUE);
             topRight.addStyleName("top-right");
             paintTopRight = new PaintOutlineWidget();
             paintTopRight.setSheetElement(sheetWidget.getTopRightPane());
             paintTopRight.setVisible(false);
-            paintTopRight.setZIndex(19);
+            paintTopRight.setZIndex(ZINDEXVALUE);
             paintTopRight.addStyleName("top-left");
         } else if (verticalSplitPosition == 0 && topRight != null) {
             topRight.remove();
@@ -678,12 +681,12 @@ public class SelectionWidget extends Composite {
             topLeft = new SelectionOutlineWidget();
             topLeft.setSheetElement(sheetWidget.getTopLeftPane());
             topLeft.setVisible(false);
-            topLeft.setZIndex(28);
+            topLeft.setZIndex(ZINDEXVALUE);
             topLeft.addStyleName("top-left");
             paintTopLeft = new PaintOutlineWidget();
             paintTopLeft.setSheetElement(sheetWidget.getTopLeftPane());
             paintTopLeft.setVisible(false);
-            paintTopLeft.setZIndex(29);
+            paintTopLeft.setZIndex(ZINDEXVALUE);
             paintTopLeft.addStyleName("top-left");
         } else if (topLeft != null
                 && (verticalSplitPosition == 0 || horizontalSplitPosition == 0)) {

--- a/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/spreadsheet-styles-valo.css
+++ b/vaadin-spreadsheet-flow/src/main/resources/META-INF/resources/frontend/vaadin-spreadsheet/spreadsheet-styles-valo.css
@@ -223,7 +223,7 @@ v-window-closebox
       clip: rect(0, 0, 0, 0);
       left: .2em;
       top: .2em;
-      z-index: 0;
+      z-index: 1;
       margin: 0; }
       :root .spreadsheetport .v-checkbox > input:focus ~ label:before {
         border-color: #197de1;
@@ -526,7 +526,7 @@ v-window-closebox
   .spreadsheetport .v-window-maximizebox,
   .spreadsheetport .v-window-restorebox {
     position: absolute;
-    z-index: 3;
+    z-index: 1;
     top: 0;
     right: 0;
     box-sizing: border-box;
@@ -685,7 +685,7 @@ v-window-closebox
       position: absolute;
       top: 0;
       width: 100%;
-      z-index: 200; }
+      z-index: 0; }
       .spreadsheetport .v-spreadsheet .functionbar .functionfield,
       .spreadsheetport .v-spreadsheet .functionbar .addressfield {
         -webkit-box-sizing: border-box;
@@ -764,7 +764,7 @@ v-window-closebox
         outline: solid #222222 1px;
         -moz-outline-offset: -2px;
         outline-offset: -2px;
-        z-index: 3; }
+        z-index: 1; }
       .spreadsheetport .v-spreadsheet .sheet .cell > .v-button {
         overflow: hidden;
         text-overflow: ellipsis; }
@@ -773,11 +773,11 @@ v-window-closebox
     .spreadsheetport .v-spreadsheet .sheet div.merged-cell {
       display: block;
       overflow: hidden;
-      z-index: 5 !important; }
+      z-index: 1 !important; }
     .spreadsheetport .v-spreadsheet .sheet div.custom-editor-cell {
       padding: 2px; }
     .spreadsheetport .v-spreadsheet .sheet.bottom-right-pane div.merged-cell {
-      z-index: 5 !important; }
+      z-index: 1 !important; }
     .spreadsheetport .v-spreadsheet .sheet > input[type="text"] {
       border: 0 !important;
       -webkit-box-shadow: 0px 0px 10px 0px rgba(0, 0, 0, 0.75);
@@ -788,7 +788,7 @@ v-window-closebox
       overflow: hidden;
       padding: 0 !important;
       position: absolute;
-      z-index: 26 !important; }
+      z-index: 1 !important; }
     .spreadsheetport .v-spreadsheet .sheet .floater {
       border-right: 0;
       border-bottom: 0;
@@ -798,10 +798,10 @@ v-window-closebox
       border-right: 0px;
       border-bottom: 0px; }
     .spreadsheetport .v-spreadsheet .top-left-pane div.merged-cell {
-      z-index: 25 !important; }
+      z-index: 1 !important; }
     .spreadsheetport .v-spreadsheet .top-right-pane div.merged-cell,
     .spreadsheetport .v-spreadsheet .bottom-left-pane div.merged-cell {
-      z-index: 15 !important; }
+      z-index: 1 !important; }
     .spreadsheetport .v-spreadsheet .top-left-pane,
     .spreadsheetport .v-spreadsheet .top-right-pane,
     .spreadsheetport .v-spreadsheet .bottom-left-pane {
@@ -821,7 +821,7 @@ v-window-closebox
       height: 100%;
       left: 0;
       padding-bottom: 28px;
-      z-index: 10; }
+      z-index: 0; }
       .spreadsheetport .v-spreadsheet .bottom-left-pane .rh {
         left: 0;
         margin-top: 0 !important; }
@@ -832,7 +832,7 @@ v-window-closebox
     .spreadsheetport .v-spreadsheet .top-left-pane {
       left: 0;
       top: 30px;
-      z-index: 20; }
+      z-index: 0; }
       .spreadsheetport .v-spreadsheet .top-left-pane .ch {
         top: 0;
         margin-left: 50px; }
@@ -848,7 +848,7 @@ v-window-closebox
     .spreadsheetport .v-spreadsheet .top-right-pane {
       top: 30px;
       width: 100%;
-      z-index: 11; }
+      z-index: 0; }
       .spreadsheetport .v-spreadsheet .top-right-pane .ch {
         top: 0;
         margin-left: 0 !important; }
@@ -883,7 +883,7 @@ v-window-closebox
       cursor: e-resize;
       -webkit-touch-callout: none;
       width: 50px;
-      z-index: 29;
+      z-index: 2;
       display: flex;
       justify-content: center;
       vertical-align: middle;
@@ -900,7 +900,7 @@ v-window-closebox
         position: absolute;
         left: 0;
         width: 49px;
-        z-index: 30; }
+        z-index: 2; }
       .spreadsheetport .v-spreadsheet .rh .header-resize-dnd-first {
         top: 0; }
       .spreadsheetport .v-spreadsheet .rh .header-resize-dnd-second {
@@ -924,7 +924,7 @@ v-window-closebox
       height: 27px;
       line-height: 27px;
       -webkit-touch-callout: none;
-      z-index: 29; }
+      z-index: 2; }
       .spreadsheetport .v-spreadsheet .ch.selected-column-header {
         background: #e6edf4 !important;
         border-bottom: 2px solid #63b1ff; }
@@ -936,7 +936,7 @@ v-window-closebox
         position: absolute;
         top: 0;
         width: 3px;
-        z-index: 30; }
+        z-index: 2; }
       .spreadsheetport .v-spreadsheet .ch .header-resize-dnd-first {
         left: 0; }
       .spreadsheetport .v-spreadsheet .ch .header-resize-dnd-second {
@@ -966,7 +966,7 @@ v-window-closebox
       padding: 0;
       visibility: hidden;
       width: 0;
-      z-index: 25;
+      z-index: 2;
       position: absolute; }
     .spreadsheetport .v-spreadsheet.col-resizing .resize-line,
     .spreadsheetport .v-spreadsheet.col-resizing .sheet > div.resize-line {
@@ -1001,7 +1001,7 @@ v-window-closebox
       height: 27px;
       border-bottom: 1px solid #C7C7C7;
       border-right: 1px solid #C7C7C7;
-      z-index: 100; }
+      z-index: 1; }
     .spreadsheetport .v-spreadsheet .sheet > div.sheet-image {
       background: transparent;
       border: none;
@@ -1010,12 +1010,12 @@ v-window-closebox
       width: auto;
       position: absolute; }
     .spreadsheetport .v-spreadsheet .bottom-right-pane.sheet > div.sheet-image {
-      z-index: 10; }
+      z-index: 1; }
     .spreadsheetport .v-spreadsheet .top-left-pane > div.sheet-image {
-      z-index: 25; }
+      z-index: 1; }
     .spreadsheetport .v-spreadsheet .top-right-pane > div.sheet-image,
     .spreadsheetport .v-spreadsheet .bottom-left-pane > div.sheet-image {
-      z-index: 15; }
+      z-index: 1; }
     .spreadsheetport .v-spreadsheet .sheet .cell-comment-triangle {
       border-color: transparent #FFCF16 transparent transparent;
       border-style: solid;
@@ -1041,7 +1041,7 @@ v-window-closebox
       right: 0;
       top: 0;
       width: 0;
-      z-index: 2; }
+      z-index: 1; }
     .spreadsheetport .v-spreadsheet .sheet .comment-overlay-line {
       background-color: #A7A7A7 !important;
       border: none !important;
@@ -1052,7 +1052,7 @@ v-window-closebox
       -webkit-transform-origin: 0% 50%;
       -ms-transform-origin: 0% 50%;
       transform-origin: 0% 50%;
-      z-index: 21; }
+      z-index: 1; }
     .spreadsheetport .v-spreadsheet div.sheet-selection {
       background-color: transparent !important;
       border: none !important;
@@ -1111,7 +1111,7 @@ v-window-closebox
       bottom: 0;
       left: 0;
       overflow: hidden;
-      z-index: 50; }
+      z-index: 1; }
       .spreadsheetport .v-spreadsheet .sheet-tabsheet .sheet-tabsheet-options {
         background: #fafafa;
         cursor: pointer;
@@ -1119,7 +1119,7 @@ v-window-closebox
         height: 28px;
         position: absolute;
         width: 130px;
-        z-index: 60;
+        z-index: 1;
         left: 0;
         top: 0; }
         .spreadsheetport .v-spreadsheet .sheet-tabsheet .sheet-tabsheet-options div {
@@ -1307,7 +1307,7 @@ v-window-closebox
       position: absolute;
       left: 0;
       width: 100%;
-      z-index: 11;
+      z-index: 1;
       background-color: #fafafa;
       border-bottom: 1px solid #C7C7C7;
       box-sizing: border-box; }
@@ -1357,7 +1357,7 @@ v-window-closebox
       .spreadsheetport .v-spreadsheet .col-group-border .border {
         position: absolute;
         width: 100%;
-        z-index: 15;
+        z-index: 1;
         border-bottom: 1px dotted #C7C7C7;
         margin-top: 20px; }
     .spreadsheetport .v-spreadsheet .row-group-pane,
@@ -1365,7 +1365,7 @@ v-window-closebox
       position: absolute;
       left: 0;
       height: 100%;
-      z-index: 11;
+      z-index: 1;
       background-color: #fafafa;
       border-right: 1px solid #C7C7C7;
       box-sizing: border-box; }
@@ -1413,7 +1413,7 @@ v-window-closebox
       .spreadsheetport .v-spreadsheet .row-group-border .border {
         position: absolute;
         height: 100%;
-        z-index: 15;
+        z-index: 1;
         border-right: 1px dotted #C7C7C7;
         /*margin-top: 20px;*/ }
     .spreadsheetport .v-spreadsheet .expandbutton {
@@ -1438,7 +1438,7 @@ v-window-closebox
     .spreadsheetport .v-spreadsheet .grouping-corner {
       position: absolute;
       left: 0;
-      z-index: 15;
+      z-index: 1;
       border-right: 1px solid #C7C7C7;
       border-bottom: 1px solid #C7C7C7;
       box-sizing: border-box;
@@ -1449,7 +1449,7 @@ v-window-closebox
       border-bottom: 1px solid #C7C7C7;
       border-right: 1px solid #C7C7C7;
       background-color: #fafafa;
-      z-index: 15; }
+      z-index: 1; }
     .spreadsheetport .v-spreadsheet .row-group-summary {
       position: absolute;
       box-sizing: border-box;
@@ -1457,7 +1457,7 @@ v-window-closebox
       border-right: 1px solid #C7C7C7;
       background-color: #fafafa;
       left: 0;
-      z-index: 15; }
+      z-index: 1; }
     .v-ie .spreadsheetport .v-spreadsheet .grouping .expand {
       line-height: 13px; }
   .spreadsheetport .v-spreadsheet-comment-overlay {


### PR DESCRIPTION
Fixes #757 #756 

This changes a random number of z-indexes used in spreadsheet, at the same time valo css has been cleaned a little bit (it needs a little more work), external font imports have been removed. This still uses the fontawesome imported from cdn which need to be fixed in separated PR.

NOTE: app-layout drawer has a `z-index=2` in spreadsheet we need at least 3 levels, 0 for cells, 1 for cells covering others, and 2 for the sheet-selection tool, thus this fix is incomplete until app-layout is modified.

**Before this PR**
![drawer-1](https://user-images.githubusercontent.com/161853/160991726-8ba9b27a-1a3f-495b-aa56-555b19c0a3a4.gif)

**After**
![drawer-2](https://user-images.githubusercontent.com/161853/160991737-42f601f0-58b0-45af-971b-2429e8a820dc.gif)

