### PR TITLE
chore: removed unused CE causing warnings in console

### DIFF
--- a/vaadin-spreadsheet-flow-integration-tests/pom.xml
+++ b/vaadin-spreadsheet-flow-integration-tests/pom.xml
@@ -18,13 +18,17 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin</artifactId>
-            <version>${vaadin.version}</version>
             <exclusions>
                 <!-- Fusion is only supported in Spring Boot currently, exclude obsolete dependencies -->
                 <exclusion>
                     <groupId>com.vaadin</groupId>
                     <artifactId>fusion-endpoint</artifactId>
                 </exclusion>
+                <!-- We do not use this, and it brings artefact with repeated elemental dependencies -->
+                <exclusion>
+                    <groupId>com.vaadin</groupId>
+                    <artifactId>collaboration-engine</artifactId>
+                </exclusion>                
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
This is a cosmetic change to avoid extra warnings in jetty container when running ITs:
```
[WARNING] elemental.json.Json scanned from multiple locations: jar:file:///Users/manolo/.m2/repository/com/vaadin/external/gwt/gwt-elemental/2.8.2.vaadin2/gwt-elemental-2.8.2.vaadin2.jar!/elemental/json/Json.class, jar:file:///Users/manolo/.m2/repository/com/google/gwt/gwt-elemental/2.8.0/gwt-elemental-2.8.0.jar!/elemental/json/Json.class
```

Reported to CE https://github.com/vaadin/collaboration-engine-internal/issues/837