### PR TITLE
chore: use imports from lit package

### DIFF
--- a/legacy/flow-webcomponent/vaadin-spreadsheet.js
+++ b/legacy/flow-webcomponent/vaadin-spreadsheet.js
@@ -12,7 +12,7 @@
  * http://polymer.github.io/PATENTS.txt
  */
 
-import {LitElement, html, css, unsafeCSS} from 'lit-element';
+import {LitElement, html, css} from 'lit';
 import { css_gwt, css_valo, Spreadsheet } from 'spreadsheet-export';
 
 /**


### PR DESCRIPTION
Lit 2.0 ships with a one-stop-shop lit package, which consolidates lit-html and lit-element.
This avoids the following warning in browser console:
>The main 'lit-element' module entrypoint is deprecated. Please update your imports to use the 'lit' package
