### PR TITLE
fix: initialize cellReference to first if undefined

### DIFF
--- a/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionManager.java
+++ b/vaadin-spreadsheet-flow/src/main/java/com/vaadin/flow/component/spreadsheet/CellSelectionManager.java
@@ -79,7 +79,9 @@ public class CellSelectionManager implements Serializable {
      * @return CellReference to selection
      */
     public CellReference getSelectedCellReference() {
-        return selectedCellReference;
+        return selectedCellReference == null
+                ? (selectedCellReference = new CellReference(0, 0))
+                : selectedCellReference;
     }
 
     /**


### PR DESCRIPTION
fixes vaadin/flow-components#3092 