### PR TITLE
fix: Block copy-paste into empty rows on a protected sheet

### DIFF
--- a/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetHandlerImpl.java
+++ b/vaadin-spreadsheet/src/main/java/com/vaadin/addon/spreadsheet/SpreadsheetHandlerImpl.java
@@ -279,6 +279,9 @@ public class SpreadsheetHandlerImpl implements SpreadsheetServerRpc {
                         return;
                     }
                 }
+            } else if (spreadsheet.isActiveSheetProtected()) {
+                protectedCellWriteAttempted();
+                return;
             }
         }
 

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/LockedCellValueTest.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/LockedCellValueTest.java
@@ -1,0 +1,163 @@
+/*
+ * Vaadin Spreadsheet Addon
+ *
+ * Copyright (C) 2013-2025 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.addon.spreadsheet.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.TimeoutException;
+import org.openqa.selenium.interactions.Actions;
+
+import com.vaadin.addon.spreadsheet.elements.SheetCellElement;
+import com.vaadin.addon.spreadsheet.elements.SpreadsheetElement;
+import com.vaadin.addon.spreadsheet.test.demoapps.LockedCellValueUI;
+import com.vaadin.testbench.elements.ButtonElement;
+
+public class LockedCellValueTest extends AbstractSpreadsheetTestCase {
+
+    private Keys cmdCtrl = Platform.getCurrent().is(Platform.MAC) ? Keys.COMMAND
+            : Keys.CONTROL;
+
+    @Override
+    protected Class<?> getUIClass() {
+        return LockedCellValueUI.class;
+    }
+
+    @Test
+    public void lockSheet_sendKeys_preventsEdit() {
+        openTestURL();
+        waitForElementPresent(By.className("v-spreadsheet"));
+
+        SpreadsheetElement spreadsheet = $(SpreadsheetElement.class).first();
+        // getCellAt is 1-based, not 0-based like spreadsheet.createCell
+        SheetCellElement cellB2 = spreadsheet.getCellAt(2, 2);
+        SheetCellElement cellC3 = spreadsheet.getCellAt(3, 3);
+        SheetCellElement cellD4 = spreadsheet.getCellAt(4, 4);
+        SheetCellElement cellE5 = spreadsheet.getCellAt(5, 5);
+
+        // confirm initial state
+
+        String b2value = cellB2.getText();
+        assertEquals("Unexpected initial B2 value,", "B2 value", b2value);
+        assertEquals("Unexpected initial C3 value,", "C3 value",
+                cellC3.getText());
+        assertEquals("Unexpected initial D4 value (not configured),", "",
+                cellD4.getText());
+        assertEquals("Unexpected initial E5 value (configured),", "",
+                cellE5.getText());
+
+        // ensure no changes happen while the entire sheet is locked
+
+        sendKeys(b2value, cellC3);
+        sendKeys(b2value, cellD4);
+        sendKeys(b2value, cellE5);
+        cellE5.waitForVaadin();
+
+        assertEquals("C3 value shouldn't have changed,", "C3 value",
+                cellC3.getValue());
+        assertEquals("D4 value shouldn't have changed,", "", cellD4.getValue());
+        assertEquals("E5 value shouldn't have changed,", "", cellE5.getValue());
+
+        // ensure it's possible to update an editable cell within a locked sheet
+
+        // make B2 and E5 editable
+        ButtonElement button = $(ButtonElement.class).first();
+        button.click();
+        button.waitForVaadin();
+
+        SheetCellElement cellE5_2 = spreadsheet.getCellAt(5, 5);
+        sendKeys(b2value, cellE5_2);
+        cellE5_2.waitForVaadin();
+
+        try {
+            waitUntil(driver -> b2value.equals(cellE5_2.getValue()));
+        } catch (TimeoutException e) {
+            fail("E5 value should be " + b2value + ", was: "
+                    + cellE5_2.getValue());
+        }
+    }
+
+    @Test
+    public void lockSheet_ctrlC_ctrlV_preventsEdit() {
+        openTestURL();
+        waitForElementPresent(By.className("v-spreadsheet"));
+
+        SpreadsheetElement spreadsheet = $(SpreadsheetElement.class).first();
+        // getCellAt is 1-based, not 0-based like spreadsheet.createCell
+        SheetCellElement cellB2 = spreadsheet.getCellAt(2, 2);
+        SheetCellElement cellC3 = spreadsheet.getCellAt(3, 3);
+        SheetCellElement cellD4 = spreadsheet.getCellAt(4, 4);
+        SheetCellElement cellE5 = spreadsheet.getCellAt(5, 5);
+
+        // confirm initial state
+
+        String b2value = cellB2.getText();
+        assertEquals("Unexpected initial B2 value,", "B2 value", b2value);
+        assertEquals("Unexpected initial C3 value,", "C3 value",
+                cellC3.getText());
+        assertEquals("Unexpected initial D4 value (not configured),", "",
+                cellD4.getText());
+        assertEquals("Unexpected initial E5 value (configured),", "",
+                cellE5.getText());
+
+        // ensure no changes happen while the entire sheet is locked
+
+        ctrlC(cellB2);
+        ctrlV(cellC3);
+        ctrlV(cellD4);
+        ctrlV(cellE5);
+
+        assertEquals("C3 value shouldn't have changed,", "C3 value",
+                cellC3.getValue());
+        assertEquals("D4 value shouldn't have changed,", "", cellD4.getValue());
+        assertEquals("E5 value shouldn't have changed,", "", cellE5.getValue());
+
+        // ensure it's possible to update an editable cell within a locked sheet
+
+        // make B2 and E5 editable
+        ButtonElement button = $(ButtonElement.class).first();
+        button.click();
+        button.waitForVaadin();
+
+        SheetCellElement cellB2_2 = spreadsheet.getCellAt(2, 2);
+        SheetCellElement cellE5_2 = spreadsheet.getCellAt(5, 5);
+        ctrlC(cellB2_2);
+        ctrlV(cellE5_2);
+        cellE5_2.waitForVaadin();
+
+        try {
+            waitUntil(driver -> b2value.equals(cellE5_2.getValue()));
+        } catch (TimeoutException e) {
+            fail("E5 value should be " + b2value + ", was: "
+                    + cellE5_2.getValue());
+        }
+    }
+
+    private void sendKeys(String value, SheetCellElement target) {
+        // target.sendKeys(value) does not work even without lock, use actions
+        new Actions(getDriver()).moveToElement(target).click().sendKeys(value)
+                .perform();
+    }
+
+    private void ctrlC(SheetCellElement target) {
+        new Actions(getDriver()).moveToElement(target).click().keyDown(cmdCtrl)
+                .sendKeys("c").keyUp(cmdCtrl).perform();
+    }
+
+    private void ctrlV(SheetCellElement target) {
+        new Actions(getDriver()).moveToElement(target).click().keyDown(cmdCtrl)
+                .sendKeys("v").keyUp(cmdCtrl).perform();
+    }
+}

--- a/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/demoapps/LockedCellValueUI.java
+++ b/vaadin-spreadsheet/src/test/java/com/vaadin/addon/spreadsheet/test/demoapps/LockedCellValueUI.java
@@ -1,0 +1,82 @@
+/*
+ * Vaadin Spreadsheet Addon
+ *
+ * Copyright (C) 2013-2025 Vaadin Ltd
+ *
+ * This program is available under Vaadin Commercial License and Service Terms.
+ *
+ * See <https://vaadin.com/commercial-license-and-service-terms> for the full
+ * license.
+ */
+package com.vaadin.addon.spreadsheet.test.demoapps;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Workbook;
+
+import com.vaadin.addon.spreadsheet.Spreadsheet;
+import com.vaadin.annotations.Theme;
+import com.vaadin.annotations.Widgetset;
+import com.vaadin.server.VaadinRequest;
+import com.vaadin.ui.Button;
+import com.vaadin.ui.Label;
+import com.vaadin.ui.UI;
+import com.vaadin.ui.VerticalLayout;
+
+@Theme("demo")
+@Widgetset("com.vaadin.addon.spreadsheet.Widgetset")
+public class LockedCellValueUI extends UI {
+
+    private Spreadsheet spreadsheet = null;
+
+    @Override
+    protected void init(VaadinRequest request) {
+        final VerticalLayout layout = new VerticalLayout();
+        layout.setWidth("1000px");
+        setContent(layout);
+
+        Label label = new Label("Protected sheet. Without toggling (button), "
+                + "it shouldn't be possible to write or copy-paste anything "
+                + "anywhere. After toggling, it should be possible to write "
+                + "and paste things into B2 and E5 only. Note that B2, C3, "
+                + "and E5 (null) are the only explicitly initialized cells. "
+                + "Manual testing should include other cells as well, such as "
+                + "A1, D4, and F6. Before the #448 fix it was possible to "
+                + "paste but not write to a cell on a row that had no "
+                + "existing initialized cells before the attempt.");
+        label.setWidthFull();
+        label.setHeightUndefined();
+        layout.addComponent(label);
+
+        spreadsheet = new Spreadsheet();
+
+        // 0-based index
+        Cell cellB2 = spreadsheet.createCell(1, 1, "B2 value");
+        spreadsheet.createCell(2, 2, "C3 value");
+        Cell cellE5 = spreadsheet.createCell(4, 4, null);
+        spreadsheet.setActiveSheetIndex(0);
+        spreadsheet.setActiveSheetProtected("protected");
+        spreadsheet.reload();
+
+        Workbook workbook = spreadsheet.getWorkbook();
+        CellStyle unLockedCellStyle = workbook.createCellStyle();
+        unLockedCellStyle.setLocked(false);
+        CellStyle lockedCellStyle = workbook.createCellStyle();
+        lockedCellStyle.setLocked(true);
+
+        Button setProtected = new Button("Toggle B2 and E5 protection",
+                event -> {
+                    if (unLockedCellStyle.equals(cellB2.getCellStyle())) {
+                        cellB2.setCellStyle(lockedCellStyle);
+                        cellE5.setCellStyle(lockedCellStyle);
+                    } else {
+                        cellB2.setCellStyle(unLockedCellStyle);
+                        cellE5.setCellStyle(unLockedCellStyle);
+                    }
+                    spreadsheet.reload();
+                });
+
+        layout.addComponent(spreadsheet);
+        layout.addComponent(setProtected);
+    }
+}


### PR DESCRIPTION
Rows that don't have any initialized cells should not allow pasting into those empty cells when the entire sheet is protected.

Fixes #448