### PR TITLE
chore: Remove references to defunct vaadin-snapshots repository and use latest Vaadin EM version by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <currentYear>2026</currentYear>
 
-        <vaadin.version>8.14.4</vaadin.version>
+        <vaadin.version>8.30.1</vaadin.version>
         <charts.version>4.3.5</charts.version>
         <testbench.version>5.1.2</testbench.version>
         <jetty.version>9.4.54.v20240208</jetty.version>

--- a/vaadin-spreadsheet-charts/pom.xml
+++ b/vaadin-spreadsheet-charts/pom.xml
@@ -42,13 +42,10 @@
         </repository>
         <repository>
             <id>vaadin-prereleases</id>
-            <name>Vaadin Pre-releases</name>
-            <url>https://maven.vaadin.com/vaadin-prereleases</url>
-        </repository>
-        <repository>
-            <id>vaadin-snapshots</id>
-            <name>Vaadin addons snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
 
@@ -62,9 +59,9 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>vaadin-snapshots</id>
-            <name>Vaadin snapshot repository</name>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <id>vaadin-prereleases</id>
+            <name>Vaadin Pre-releases</name>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
         </snapshotRepository>
         <repository>
             <id>vaadin-addons</id>

--- a/vaadin-spreadsheet-testbench-api/pom.xml
+++ b/vaadin-spreadsheet-testbench-api/pom.xml
@@ -31,13 +31,20 @@
             <id>vaadin-addons</id>
             <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
+        <repository>
+            <id>vaadin-prereleases</id>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <distributionManagement>
         <snapshotRepository>
-            <id>vaadin-snapshots</id>
-            <name>Vaadin snapshot repository</name>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <id>vaadin-prereleases</id>
+            <name>Vaadin Pre-releases</name>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
         </snapshotRepository>
         <repository>
             <id>vaadin-addons</id>

--- a/vaadin-spreadsheet/pom.xml
+++ b/vaadin-spreadsheet/pom.xml
@@ -23,7 +23,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <currentYear>2026</currentYear>
         
-        <vaadin.version>8.14.4</vaadin.version>
+        <vaadin.version>8.30.1</vaadin.version>
         <charts.version>4.3.5</charts.version>
         <testbench.version>5.1.2</testbench.version>
         <jetty.version>9.4.54.v20240208</jetty.version>
@@ -406,15 +406,13 @@
                 <directory>src/main/webapp</directory>
             </resource>
         </resources>
-
-
-
     </build>
+
     <distributionManagement>
         <snapshotRepository>
-            <id>vaadin-snapshots</id>
-            <name>Vaadin snapshot repository</name>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
+            <id>vaadin-prereleases</id>
+            <name>Vaadin Pre-releases</name>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
         </snapshotRepository>
         <repository>
             <id>vaadin-addons</id>
@@ -425,25 +423,12 @@
 
     <repositories>
         <repository>
-            <id>vaadin-prereleases</id>
-            <name>Vaadin Pre-releases</name>
-            <url>https://maven.vaadin.com/vaadin-prereleases</url>
-        </repository>
-
-        <repository>
-            <id>Vaadin releases</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-releases</url>
-        </repository>
-        <repository>
             <id>vaadin-addons</id>
             <url>https://maven.vaadin.com/vaadin-addons</url>
         </repository>
         <repository>
-            <id>vaadin-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
+            <id>vaadin-prereleases</id>
+            <url>https://maven.vaadin.com/vaadin-prereleases/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>
@@ -455,16 +440,6 @@
             <id>vaadin-prereleases</id>
             <name>Vaadin Pre-releases</name>
             <url>https://maven.vaadin.com/vaadin-prereleases</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>vaadin-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/vaadin-snapshots/</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
         </pluginRepository>
     </pluginRepositories>
 


### PR DESCRIPTION
The project POMs referenced a now-discontinued Maven repository, which made any attempt to build take forever as Maven would attempt to contact the old repository and had to wait until the requests timed out.

Also use latest Vaadin EM version by default to avoid wasted time when testing for bugs traceable to Vaadin core.